### PR TITLE
Normalize additive functions and capture missing taxonomy entries

### DIFF
--- a/data/additives.json
+++ b/data/additives.json
@@ -1,162 +1,32 @@
 {
   "additives": [
     {
-      "title": "Allura Red AC",
-      "eNumber": "E129",
+      "title": "1‚4-Heptonolactone",
+      "eNumber": "E370",
       "synonyms": [
-        "E129",
-        "Allura red",
-        "Allura red ac",
-        "Allura Red AC",
-        "FD&C Red 40",
-        "FD and C Red 40",
-        "Red 40",
-        "Red no40",
-        "Red no. 40",
-        "FD and C Red no. 40",
-        "Food Red 17",
-        "C.I. 16035",
-        "Red 40 lake"
-      ],
-      "functions": [
-        "colour"
-      ],
-      "description": "Allura Red AC is a red azo dye that goes by several names, including FD&C Red 40. It is used as a food dye and has the E number E129. It is usually supplied as its red sodium salt, but can also be used as the calcium and potassium salts. These salts are soluble in water. In solution, its maximum absorbance lies at about 504 nm.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Allura Red AC",
-      "wikidata": "Q419895"
-    },
-    {
-      "title": "Titanium dioxide",
-      "eNumber": "E171",
-      "synonyms": [
-        "E171",
-        "Titanium dioxide"
-      ],
-      "functions": [
-        "colour"
-      ],
-      "description": "Titanium dioxide, also known as titaniumIV oxide or titania, is the naturally occurring oxide of titanium, chemical formula TiO2. When used as a pigment, it is called titanium white, Pigment White 6 -PW6-, or CI 77891. Generally, it is sourced from ilmenite, rutile and anatase. It has a wide range of applications, including paint, sunscreen and food coloring. When used as a food coloring, it has E number E171. World production in 2014 exceeded 9 million metric tons. It has been estimated that titanium dioxide is used in two-thirds of all pigments, and the oxide has been valued at $13.2 billion.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Titanium_dioxide",
-      "wikidata": "Q193521"
-    },
-    {
-      "title": "Sorbic acid",
-      "eNumber": "E200",
-      "synonyms": [
-        "E200",
-        "Sorbic acid"
-      ],
-      "functions": [
-        "preservative"
-      ],
-      "description": "Sorbic acid, or 2‚4-hexadienoic acid, is a natural organic compound used as a food preservative. It has the chemical formula CH3-CH-4CO2H. It is a colourless solid that is slightly soluble in water and sublimes readily. It was first isolated from the unripe berries of the Sorbus aucuparia -rowan tree-, hence its name.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Sorbic_acid",
-      "wikidata": "Q407131"
-    },
-    {
-      "title": "Sulfur dioxide",
-      "eNumber": "E220",
-      "synonyms": [
-        "E220",
-        "Sulphur dioxide",
-        "Sulfur dioxide"
-      ],
-      "functions": [
-        "antioxidant",
-        "preservative"
-      ],
-      "description": "Sulfur dioxide -also sulphur dioxide in British English- is the chemical compound with the formula SO2. It is a toxic gas with a burnt match smell. It is released naturally by volcanic activity and is produced as a by-product of the burning of fossil fuels contaminated with sulfur compounds.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Sulfur_dioxide",
-      "wikidata": "Q5282"
-    },
-    {
-      "title": "Lactic acid",
-      "eNumber": "E270",
-      "synonyms": [
-        "E270",
-        "Lactic acid",
-        "milk acid",
-        "2-Hydroxypropanoic acid"
+        "E370",
+        "1‚4-Heptonolactone"
       ],
       "functions": [],
-      "description": "Lactic acid is an organic compound with the formula CH3CH-OH-COOH.  In its solid state, it is white and water-soluble. In its liquid state, it is colorless. It is produced both naturally and synthetically. With a hydroxyl group adjacent to the carboxyl group, lactic acid is classified as an alpha-hydroxy acid -AHA-.  In the form of its conjugate base called lactate, it plays a role in several biochemical processes. In solution, it can ionize a proton from the carboxyl group, producing the lactate ion CH3CH-OH-CO−2. Compared to acetic acid, its pKa is 1 unit less, meaning lactic acid deprotonates ten times more easily than acetic acid does. This higher acidity is the consequence of the intramolecular hydrogen bonding between the α-hydroxyl and the carboxylate group. Lactic acid is chiral, consisting of two optical isomers. One is known as L--+--lactic acid or -S--lactic acid and the other, its mirror image, is D--−--lactic acid or -R--lactic acid. A mixture of the two in equal amounts is called DL-lactic acid, or racemic lactic acid. Lactic acid is hygroscopic. DL-lactic acid is miscible with water and with ethanol above its melting point which is around 17 or 18 °C. D-lactic acid and L-lactic acid have a higher melting point. In animals, L-lactate is constantly produced from pyruvate via the enzyme lactate dehydrogenase -LDH- in a process of fermentation during normal metabolism and exercise. It does not increase in concentration until the rate of lactate production exceeds the rate of lactate removal, which is governed by a number of factors, including monocarboxylate transporters, concentration and isoform of LDH, and oxidative capacity of tissues. The concentration of blood lactate is usually 1–2 mM at rest, but can rise to over 20 mM during intense exertion and as high as 25 mM afterward. In addition to other biological roles, L-lactic acid is the primary endogenous agonist of hydroxycarboxylic acid receptor 1 -HCA1-, which is a Gi/o-coupled G protein-coupled receptor -GPCR-.In industry, lactic acid fermentation is performed by lactic acid bacteria, which convert simple carbohydrates such as glucose, sucrose, or galactose to lactic acid. These bacteria can also grow in the mouth; the acid they produce is responsible for the tooth decay known as caries. In medicine, lactate is one of the main components of lactated Ringer's solution and Hartmann's solution. These intravenous fluids consist of sodium and potassium cations along with lactate and chloride anions in solution with distilled water, generally in concentrations isotonic with human blood. It is most commonly used for fluid resuscitation after blood loss due to trauma, surgery, or burns.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Lactic_acid",
-      "wikidata": "Q56626856"
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
     },
     {
-      "title": "Citric acid",
-      "eNumber": "E330",
+      "title": "4-hexylresorcinol",
+      "eNumber": "E586",
       "synonyms": [
-        "E330",
-        "Citric acid"
+        "E586",
+        "4-hexylresorcinol",
+        "4-Hexyl-1‚3-benzenediol"
       ],
-      "functions": [
-        "antioxidant",
-        "sequestrant"
-      ],
-      "description": "Citric acid is a weak organic acid that has the chemical formula C6H8O7. It occurs naturally in citrus fruits. In biochemistry, it is an intermediate in the citric acid cycle, which occurs in the metabolism of all aerobic organisms. More than a million tons of citric acid are manufactured every year. It is used  widely as an acidifier, as a flavoring and chelating agent.A citrate is a derivative of citric acid; that is, the salts, esters, and the polyatomic anion found in solution. An example of the former, a salt is trisodium citrate; an ester is triethyl citrate. When part of a salt, the formula of the citrate ion is written as C6H5O3−7 or C3H5O-COO-3−3.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Citric_acid",
-      "wikidata": "Q159683"
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
     },
     {
-      "title": "Carrageenan",
-      "eNumber": "E407",
-      "synonyms": [
-        "E407",
-        "Carrageenan",
-        "e407 stabilizer"
-      ],
-      "functions": [
-        "carrier",
-        "emulsifier",
-        "humectant",
-        "stabiliser",
-        "thickener"
-      ],
-      "description": "Carrageenans or carrageenins - karr-ə-gee-nənz, from Irish carraigín, \"little rock\"- are a family of linear sulfated polysaccharides that are extracted from red edible seaweeds. They are widely used in the food industry, for their gelling, thickening, and stabilizing properties. Their main application is in dairy and meat products, due to their strong binding to food proteins. There are three main varieties of carrageenan, which differ in their degree of sulfation. Kappa-carrageenan has one sulfate group per disaccharide, iota-carrageenan has two, and lambda-carrageenan has three. Gelatinous extracts of the Chondrus crispus -Irish moss- seaweed have been used as food additives since approximately the fifteenth century. Carrageenan is a vegetarian and vegan alternative to gelatin in some applications or may be used to replace gelatin in confectionery.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Carrageenan",
-      "wikidata": "Q421991"
-    },
-    {
-      "title": "Locust bean gum",
-      "eNumber": "E410",
-      "synonyms": [
-        "E410",
-        "Locust bean gum",
-        "Carob bean gum",
-        "Carob gum",
-        "garrofin gum",
-        "peruvian carob gum"
-      ],
-      "functions": [
-        "emulsifier",
-        "stabiliser",
-        "thickener"
-      ],
-      "description": "Locust bean gum -LBG, also known as carob gum, carob bean gum, carobin, E410- is a thickening agent and a gelling agent used in food technology.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Locust bean gum",
-      "wikidata": "Q221391"
-    },
-    {
-      "title": "Guar gum",
-      "eNumber": "E412",
-      "synonyms": [
-        "E412",
-        "Guar gum",
-        "Gum cyamopsis",
-        "guar flour"
-      ],
-      "functions": [
-        "emulsifier",
-        "stabiliser",
-        "thickener"
-      ],
-      "description": "Guar gum, also called guaran, is a galactomannan polysaccharide extracted from guar beans that has thickening and stabilizing properties useful in the food, feed and industrial applications. The guar seeds are mechanically dehusked, hydrated, milled and screened according to application. It is typically produced as a free-flowing, off-white powder.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Guar gum",
-      "wikidata": "Q422071"
-    },
-    {
-      "title": "Gum arabic",
+      "title": "Acacia gum",
       "eNumber": "E414",
       "synonyms": [
         "E414",
@@ -181,6 +51,9282 @@
       "wikidata": "Q535814"
     },
     {
+      "title": "Acesulfame k",
+      "eNumber": "E950",
+      "synonyms": [
+        "E950",
+        "Acesulfame k",
+        "Acesulfame potassium"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Acesulfame potassium - AY-see-SUL-faym-, also known as acesulfame K  -K is the symbol for potassium- or Ace K, is a calorie-free sugar substitute -artificial sweetener- often marketed under the trade names Sunett and Sweet One. In the European Union, it is known under the E number -additive code- E950. It was discovered accidentally in 1967 by German chemist Karl Clauss at Hoechst AG -now Nutrinova-. In chemical structure, acesulfame potassium is the potassium salt of 6-methyl-1‚2,3-oxathiazine-4-3H--one 2‚2-dioxide. It is a white crystalline powder with molecular formula C4H4KNO4S and a molecular weight of 201.24 g/mol.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Acesulfame_potassium",
+      "wikidata": "Q132037"
+    },
+    {
+      "title": "Acetic acid",
+      "eNumber": "E260",
+      "synonyms": [
+        "E260",
+        "Acetic acid",
+        "ethanoic acid"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Acetic acid , systematically named ethanoic acid , is a colorless liquid organic compound with the chemical formula CH3COOH -also written as CH3CO2H or C2H4O2-. When undiluted, it is sometimes called glacial acetic acid. Vinegar is no less than 4% acetic acid by volume, making acetic acid the main component of vinegar apart from water. Acetic acid has a distinctive sour taste and pungent smell. In addition to household vinegar, it is mainly produced as a precursor to polyvinyl acetate and cellulose acetate. It is classified as a weak acid since it only partially dissociates in solution, but concentrated acetic acid is corrosive and can attack the skin. Acetic acid is the second simplest carboxylic acid -after formic acid-. It consists of a methyl group attached to a carboxyl group. It is an important chemical reagent and industrial chemical, used primarily in the production of cellulose acetate for photographic film, polyvinyl acetate for wood glue, and synthetic fibres and fabrics. In households, diluted acetic acid is often used in descaling agents. In the food industry, acetic acid is controlled by the food additive code E260 as an acidity regulator and as a condiment. In biochemistry, the acetyl group, derived from acetic acid, is fundamental to all forms of life. When bound to coenzyme A, it is central to the metabolism of carbohydrates and fats. The global demand for acetic acid is about 6.5 million metric tons per year -Mt/a-, of which approximately 1.5 Mt/a is met by recycling; the remainder is manufactured from methanol. Vinegar is mostly dilute acetic acid, often produced by fermentation and subsequent oxidation of ethanol.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Acetic_acid",
+      "wikidata": "Q47512"
+    },
+    {
+      "title": "Acetic acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472A",
+      "synonyms": [
+        "E472a",
+        "Acetic acid esters of mono- and diglycerides of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q26806065"
+    },
+    {
+      "title": "acetone peroxide",
+      "eNumber": "E929",
+      "synonyms": [
+        "E929",
+        "acetone peroxide",
+        "Mother of Satan",
+        "Triacetone Triperoxide",
+        "Peroxyacetone"
+      ],
+      "functions": [],
+      "description": "Acetone peroxide is an organic peroxide and a primary high explosive. It is produced by the reaction of acetone and hydrogen peroxide to yield a mixture of linear monomer and cyclic dimer, trimer, and tetramer forms. The trimer is known as triacetone triperoxide -TATP- or tri-cyclic acetone peroxide -TCAP-. The dimer is known as diacetone diperoxide -DADP-. Acetone peroxide takes the form of a white crystalline powder with a distinctive bleach-like odor -when impure- or a fruit-like smell when pure and can explode if subjected to heat, friction, static electricity, concentrated sulfuric acid, strong UV radiation or shock. As a non-nitrogenous explosive, TATP has historically been more difficult to detect, and it has been used as an explosive in several terrorist attacks since 2001.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Acetone_peroxide",
+      "wikidata": "Q329022"
+    },
+    {
+      "title": "Acetylated distarch adipate",
+      "eNumber": "E1422",
+      "synonyms": [
+        "E1422",
+        "Acetylated distarch adipate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Acetylated distarch adipate -E1422-, is a starch that is treated with acetic anhydride and adipic acid anhydride to resist high temperatures.  It is used in foods as a bulking agent, stabilizer and a thickener. No acceptable daily intake for human consumption has been determined.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Acetylated_distarch_adipate",
+      "wikidata": "Q2824457"
+    },
+    {
+      "title": "Acetylated distarch phosphate",
+      "eNumber": "E1414",
+      "synonyms": [
+        "E1414",
+        "Acetylated distarch phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967180"
+    },
+    {
+      "title": "Acetylated oxidised starch",
+      "eNumber": "E1451",
+      "synonyms": [
+        "E1451",
+        "Acetylated oxidised starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q2633813"
+    },
+    {
+      "title": "Acetylated starch",
+      "eNumber": "E1420",
+      "synonyms": [
+        "E1420",
+        "Acetylated starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18935684"
+    },
+    {
+      "title": "Acetylated starch",
+      "eNumber": "E1421",
+      "synonyms": [
+        "E1421",
+        "Acetylated starch",
+        "mono starch acetate",
+        "Starch acetate esterified with vinyl acetate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18944665"
+    },
+    {
+      "title": "acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472",
+      "synonyms": [
+        "E472",
+        "acid esters of mono- and diglycerides of fatty acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Acid sodium aluminium phosphate",
+      "eNumber": "E541I",
+      "synonyms": [
+        "E541i",
+        "Acid sodium aluminium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium aluminium phosphate -SAlP- describes the inorganic compounds consisting of sodium salts of aluminium phosphates.  The most common SAlP has the formulas NaH14Al3-PO4-8·4H2O and Na3H15Al2-PO4-8. These materials are prepared by combining alumina, phosphoric acid, and sodium hydroxide.In addition to the usual hydrate, an anhydrous SAlP is also known, Na3H15Al2-PO4-8 -CAS#10279-59-1-, referred to as 8:2:3, reflecting the ratio of phosphate to aluminium to sodium.  Additionally an SAlP of ill-defined stoichiometry is used -NaxAly-PO4-z -CAS# 7785-88-8-.The acidic sodium aluminium phosphates are used as acids for baking powders for the chemical leavening of baked goods. Upon heating, SAlP combines with the baking soda to give carbon dioxide.  Most of its action occurs at baking temperatures, rather than when the dough or batter is mixed at room temperature.  SAlPs are advantageous because they impart a neutral flavor.   As a food additive, it has the E number E541.  Basic sodium aluminium phosphates are also known, e.g., Na15Al3-PO4-8.  These species are useful in cheese making.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_aluminium_phosphate",
+      "wikidata": "Q1220360"
+    },
+    {
+      "title": "Acid-treated modified starch",
+      "eNumber": "E1401",
+      "synonyms": [
+        "E1401",
+        "Acid-treated modified starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967250"
+    },
+    {
+      "title": "Adipic acid",
+      "eNumber": "E355",
+      "synonyms": [
+        "E355",
+        "Adipic acid",
+        "Hexanedioic acid"
+      ],
+      "functions": [],
+      "description": "Adipic acid or hexanedioic acid is the organic compound with the formula -CH2-4-COOH-2. From an industrial perspective, it is the most important dicarboxylic acid: About 2.5 billion kilograms of this white crystalline powder are produced annually, mainly as a precursor for the production of nylon.  Adipic acid otherwise rarely occurs in nature.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Adipic_acid",
+      "wikidata": "Q357415"
+    },
+    {
+      "title": "Advantame",
+      "eNumber": "E969",
+      "synonyms": [
+        "E969",
+        "Advantame"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Agar",
+      "eNumber": "E406",
+      "synonyms": [
+        "E406",
+        "Agar",
+        "Gelose",
+        "Kanten",
+        "Bengal",
+        "Ceylon",
+        "Chinese or Japanese isinglass",
+        "agar-agar",
+        "agar agar"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Agar -pronounced , sometimes - or agar-agar is a jelly-like substance, obtained from red algae.Agar is a mixture of two components: the linear polysaccharide agarose, and a heterogeneous mixture of smaller molecules called agaropectin.  It forms the supporting structure in the cell walls of certain species of algae, and is released on boiling. These algae are known as agarophytes, and belong to the Rhodophyta -red algae- phylum.Agar has been used as an ingredient in desserts throughout Asia, and also as a solid substrate to contain culture media for microbiological work. Agar can be used as a laxative, an appetite suppressant, a vegetarian substitute for gelatin, a thickener for soups, in fruit preserves, ice cream, and other desserts, as a clarifying agent in brewing, and for sizing paper and fabrics.The gelling agent in agar is an unbranched polysaccharide obtained from the cell walls of some species of red algae, primarily from tengusa -Gelidiaceae- and ogonori -Gracilaria-. For commercial purposes, it is derived primarily from ogonori. In chemical terms, agar is a polymer made up of subunits of the sugar galactose.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Agar",
+      "wikidata": "Q177998"
+    },
+    {
+      "title": "Alanin",
+      "eNumber": "E369",
+      "synonyms": [
+        "E369",
+        "Alanin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Algal carotenes",
+      "eNumber": "E160AIV",
+      "synonyms": [
+        "E160aiv",
+        "Algal carotenes"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Alginic acid",
+      "eNumber": "E400",
+      "synonyms": [
+        "E400",
+        "Alginic acid"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Alginic acid, also called algin or alginate,  is a polysaccharide distributed widely in the cell walls of brown algae, where through binding with water it forms a viscous gum. It is also a significant component of the biofilms produced by the bacterium Pseudomonas aeruginosa, the major pathogen in cystic fibrosis, that confer it a high resistance to antibiotics and killing by macrophages.  Its colour ranges from white to yellowish-brown. It is sold in filamentous, granular or powdered forms.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Alginic_acid",
+      "wikidata": "Q422092"
+    },
+    {
+      "title": "Alkaline modified starch",
+      "eNumber": "E1402",
+      "synonyms": [
+        "E1402",
+        "Alkaline modified starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18636175"
+    },
+    {
+      "title": "Alkannin",
+      "eNumber": "E103",
+      "synonyms": [
+        "E103",
+        "Alkannin"
+      ],
+      "functions": [],
+      "description": "Alkannin is a natural dye that is obtained from the extracts of plants from the borage family Alkanna tinctoria that are found in the south of France. The dye is used as a food coloring and in cosmetics. It is used as a red-brown food additive in regions such as Australia, and is designated in Europe as the E number E103, but is no longer approved for use.  Alkannin has a deep red color in a greasy or oily environment and a violet color in an alkaline environment.The chemical structure as a naphthoquinone derivative was first determined by Brockmann in 1936.  The enantiomer of alkannin is known as shikonin, and the racemic mixture of the two is known as shikalkin.The enzyme 4-hydroxybenzoate geranyltransferase utilizes geranyl diphosphate and 4-hydroxybenzoate to produce 3-geranyl-4-hydroxybenzoate and diphosphate. These compounds are then used to form alkannin.Alkannin is an antioxidant and has an antimicrobial effect against Staphylococcus aureus and Staphylococcus epidermidis. It is also known to have wound healing, antitumor, and antithrombotic properties.  Shikonin is also found in the Chinese herbal medicine plant Lithospermum erythrorhizon, the red-root gromwell, -紫草 zicao, Pinyin: zǐcǎo-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Alkannin",
+      "wikidata": "Q418237"
+    },
+    {
+      "title": "Allura red",
+      "eNumber": "E129",
+      "synonyms": [
+        "E129",
+        "Allura red",
+        "Allura red ac",
+        "Allura Red AC",
+        "FD&C Red 40",
+        "FD and C Red 40",
+        "Red 40",
+        "Red no40",
+        "Red no. 40",
+        "FD and C Red no. 40",
+        "Food Red 17",
+        "C.I. 16035",
+        "Red 40 lake"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Allura Red AC is a red azo dye that goes by several names, including FD&C Red 40. It is used as a food dye and has the E number E129. It is usually supplied as its red sodium salt, but can also be used as the calcium and potassium salts. These salts are soluble in water. In solution, its maximum absorbance lies at about 504 nm.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Allura_Red_AC",
+      "wikidata": "Q419895"
+    },
+    {
+      "title": "Alpha-Amylase",
+      "eNumber": "E1100",
+      "synonyms": [
+        "E1100",
+        "Alpha-Amylase",
+        "amylase",
+        "E-1100",
+        "E 1100"
+      ],
+      "functions": [],
+      "description": "An amylase -- is an enzyme that catalyses the hydrolysis of starch into sugars. Amylase is present in the saliva of humans and some other mammals, where it begins the chemical process of digestion. Foods that contain large amounts of starch but little sugar, such as rice and potatoes, may acquire a slightly sweet taste as they are chewed because amylase degrades some of their starch into sugar. The pancreas and salivary gland make amylase -alpha amylase- to hydrolyse dietary starch into disaccharides and trisaccharides which are converted by other enzymes to glucose to supply the body with energy. Plants and some bacteria also produce amylase. As diastase, amylase was the first enzyme to be discovered and isolated -by Anselme Payen in 1833-. Specific amylase proteins are designated by different Greek letters. All amylases are glycoside hydrolases and act on α-1‚4-glycosidic bonds.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Amylase",
+      "wikidata": "Q17153"
+    },
+    {
+      "title": "Alpha-Cyclodextrine",
+      "eNumber": "E457",
+      "synonyms": [
+        "E457",
+        "Alpha-Cyclodextrine"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Alpha-tocopherol",
+      "eNumber": "E307",
+      "synonyms": [
+        "E307",
+        "Alpha-tocopherol"
+      ],
+      "functions": [],
+      "description": "α-Tocopherol is a type of vitamin E. It has E number \"E307\". Vitamin E exists in eight different forms, four tocopherols and four tocotrienols. All feature a chromane ring, with a hydroxyl group that can donate a hydrogen atom to reduce free radicals and a hydrophobic side chain which allows for penetration into biological membranes. Compared to the others, α-tocopherol is preferentially absorbed and accumulated in humans.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Alpha-Tocopherol",
+      "wikidata": "Q158348"
+    },
+    {
+      "title": "Aluminium",
+      "eNumber": "E173",
+      "synonyms": [
+        "E173",
+        "Aluminium",
+        "Aluminum",
+        "element 13"
+      ],
+      "functions": [],
+      "description": "Aluminium or aluminum is a chemical element with symbol Al and atomic number 13. It is a silvery-white, soft, nonmagnetic and ductile metal in the boron group. By mass, aluminium makes up about 8% of the  Earth's crust; it is the third most abundant element after oxygen and silicon and the most abundant metal in the crust, though it is less common in the mantle below. The chief ore of aluminium is bauxite. Aluminium metal is so chemically reactive that native specimens are rare and limited to extreme reducing environments. Instead, it is found combined in over 270 different minerals.Aluminium is remarkable for its low density and its ability to resist corrosion through the phenomenon of passivation. Aluminium and its alloys are vital to the aerospace industry and important in transportation and building industries, such as building facades and window frames. The oxides and sulfates are the most useful compounds of aluminium.Despite its prevalence in the environment, no known form of life uses aluminium salts metabolically, but aluminium is well tolerated by plants and animals. Because of these salts' abundance, the potential for a biological role for them is of continuing interest, and studies continue.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Aluminium",
+      "wikidata": "Q663"
+    },
+    {
+      "title": "Aluminium ammonium sulphate",
+      "eNumber": "E523",
+      "synonyms": [
+        "E523",
+        "Aluminium ammonium sulphate",
+        "ammonium aluminium sulfate"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q419370"
+    },
+    {
+      "title": "Aluminium potassium sulphate",
+      "eNumber": "E522",
+      "synonyms": [
+        "E522",
+        "Aluminium potassium sulphate",
+        "Potassium alum",
+        "Potassium aluminium sulfate",
+        "potash alum"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q411309"
+    },
+    {
+      "title": "Aluminium silicate",
+      "eNumber": "E559",
+      "synonyms": [
+        "E559",
+        "Aluminium silicate",
+        "Kaolin"
+      ],
+      "functions": [],
+      "description": "Aluminium silicate -or aluminum silicate- is a name commonly applied to chemical compounds which are derived from aluminium oxide, Al2O3 and silicon dioxide, SiO2 which may be anhydrous or hydrated, naturally occurring as minerals or synthetic. Their chemical formulae are often expressed as xAl2O3.ySiO2.zH2O",
+      "wikipedia": "https://en.wikipedia.org/wiki/Aluminium_silicate",
+      "wikidata": "Q1284687"
+    },
+    {
+      "title": "Aluminium sodium sulphate",
+      "eNumber": "E521",
+      "synonyms": [
+        "E521",
+        "Aluminium sodium sulphate",
+        "Soda alum",
+        "Sodium aluminium sulfate"
+      ],
+      "functions": [],
+      "description": "Sodium aluminium sulfate is the inorganic compound with the chemical formula NaAl-SO4-2·12H2O  -sometimes written Na2SO4·Al2-SO4-3·24H2O-.  Also known as soda alum, sodium alum, or SAS, this white solid is used in the manufacture of baking powder and as a food additive.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_aluminium_sulfate",
+      "wikidata": "Q413559"
+    },
+    {
+      "title": "Aluminium stearate",
+      "eNumber": "E573",
+      "synonyms": [
+        "E573",
+        "Aluminium stearate",
+        "Aluminum stearate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Aluminium sulphate",
+      "eNumber": "E520",
+      "synonyms": [
+        "E520",
+        "Aluminium sulphate",
+        "Aluminium sulfate"
+      ],
+      "functions": [],
+      "description": "Aluminium sulfate is a chemical compound with the formula Al2-SO4-3. It is soluble in water and is mainly used as a coagulating agent -promoting particle collision by neutralizing charge- in the purification of drinking water and waste water treatment plants, and also in paper manufacturing. The anhydrous form occurs naturally as a rare mineral millosevichite, found e.g. in volcanic environments and on burning coal-mining waste dumps. Aluminium sulfate is rarely, if ever, encountered as the anhydrous salt. It forms a number of different hydrates, of which the hexadecahydrate Al2-SO4-3•16H2O and octadecahydrate Al2-SO4-3•18H2O are the most common. The heptadecahydrate, whose formula can be written as [Al-H2O-6]2-SO4-3•5H2O, occurs naturally as the mineral alunogen. Aluminium sulfate is sometimes called alum or papermaker's alum in certain industries. However, the name \"alum\" is more commonly and properly used for any double sulfate salt with the generic formula XAl-SO4-2·12H2O, where X is a monovalent cation such as potassium or ammonium.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Aluminium_sulfate",
+      "wikidata": "Q421857"
+    },
+    {
+      "title": "Amaranth",
+      "eNumber": "E123",
+      "synonyms": [
+        "E123",
+        "Amaranth",
+        "FD&C Red 2"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Amaranth, FD&C Red No. 2, E123, C.I. Food Red 9, Acid Red 27, Azorubin S, or C.I. 16185 is a dark red to purple azo dye used as a food dye and to color cosmetics. The name was taken from amaranth grain, a plant distinguished by its red color and edible protein-rich seeds. Amaranth is an anionic dye. It can be applied to natural and synthetic fibers, leather, paper, and phenol-formaldehyde resins. As a food additive it has E number E123. Amaranth usually comes as a trisodium salt. It has the appearance of reddish-brown, dark red to purple water-soluble powder that decomposes at 120 °C without melting. Its water solution has absorption maximum at about 520 nm.  Like all azo dyes, Amaranth was, during the middle of the 20th century, made from coal tar; modern synthetics are more likely to be made from petroleum byproducts.Since 1976 Amaranth has been banned in the United States by the Food and Drug Administration -FDA- as a suspected carcinogen. Its use is still legal in some countries, notably in the United Kingdom where it is most commonly used to give Glacé cherries their distinctive color.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Amaranth_-dye-",
+      "wikidata": "Q421074"
+    },
+    {
+      "title": "Amidated pectin",
+      "eNumber": "E440II",
+      "synonyms": [
+        "E440ii",
+        "Amidated pectin"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Pectin -from Ancient Greek: πηκτικός pēktikós, \"congealed, curdled\"- is a structural heteropolysaccharide contained in the primary cell walls of terrestrial plants. It was first isolated and described in 1825 by Henri Braconnot. It is produced commercially as a white to light brown powder, mainly extracted from citrus fruits, and is used in food as a gelling agent, particularly in jams and jellies. It is also used in dessert fillings, medicines, sweets, as a stabilizer in fruit juices and milk drinks, and as a source of dietary fiber.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pectin",
+      "wikidata": "Q42807519"
+    },
+    {
+      "title": "Amino acids",
+      "eNumber": "",
+      "synonyms": [
+        "Amino acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Ammonia caramel",
+      "eNumber": "E150C",
+      "synonyms": [
+        "E150c",
+        "Ammonia caramel",
+        "baker's caramel",
+        "confectioner's caramel",
+        "beer caramel",
+        "Caramel Color Ammonia",
+        "Caramel Color"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q11735907"
+    },
+    {
+      "title": "Ammonium acetate",
+      "eNumber": "E264",
+      "synonyms": [
+        "E264",
+        "Ammonium acetate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "ammonium adipate",
+      "eNumber": "E359",
+      "synonyms": [
+        "E359",
+        "ammonium adipate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q4747299"
+    },
+    {
+      "title": "Ammonium alginate",
+      "eNumber": "E403",
+      "synonyms": [
+        "E403",
+        "Ammonium alginate"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q16038948"
+    },
+    {
+      "title": "Ammonium and sodium carbonates",
+      "eNumber": "",
+      "synonyms": [
+        "ammonium and sodium carbonates"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Ammonium carbonate",
+      "eNumber": "E503I",
+      "synonyms": [
+        "E503i",
+        "Ammonium carbonate"
+      ],
+      "functions": [],
+      "description": "Ammonium carbonate is a salt with the chemical formula -NH4-2CO3. Since it readily degrades to gaseous ammonia and carbon dioxide upon heating, it is used as a leavening agent and also as smelling salt. It is also known as baker's ammonia and was a predecessor to the more modern leavening agents baking soda and baking powder. It is a component of what was formerly known as sal volatile and salt of hartshorn.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_carbonate",
+      "wikidata": "Q204873"
+    },
+    {
+      "title": "Ammonium carbonates",
+      "eNumber": "E503",
+      "synonyms": [
+        "E503",
+        "Ammonium carbonates"
+      ],
+      "functions": [],
+      "description": "Ammonium carbonate is a salt with the chemical formula -NH4-2CO3. Since it readily degrades to gaseous ammonia and carbon dioxide upon heating, it is used as a leavening agent and also as smelling salt. It is also known as baker's ammonia and was a predecessor to the more modern leavening agents baking soda and baking powder. It is a component of what was formerly known as sal volatile and salt of hartshorn.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_carbonate",
+      "wikidata": "Q204873"
+    },
+    {
+      "title": "Ammonium chloride",
+      "eNumber": "E510",
+      "synonyms": [
+        "E510",
+        "Ammonium chloride",
+        "ammonia solution"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_chloride",
+      "wikidata": "Q188543"
+    },
+    {
+      "title": "Ammonium hydrogen carbonate",
+      "eNumber": "E503II",
+      "synonyms": [
+        "E503ii",
+        "Ammonium hydrogen carbonate",
+        "Baker's ammonia",
+        "Sal volatile",
+        "Salt of hartshorn",
+        "Ammonium bicarbonate"
+      ],
+      "functions": [],
+      "description": "Ammonium carbonate is a salt with the chemical formula -NH4-2CO3. Since it readily degrades to gaseous ammonia and carbon dioxide upon heating, it is used as a leavening agent and also as smelling salt. It is also known as baker's ammonia and was a predecessor to the more modern leavening agents baking soda and baking powder. It is a component of what was formerly known as sal volatile and salt of hartshorn.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_bicarbonate",
+      "wikidata": "Q421123"
+    },
+    {
+      "title": "Ammonium hydroxide",
+      "eNumber": "E527",
+      "synonyms": [
+        "E527",
+        "Ammonium hydroxide",
+        "Aqua ammonia",
+        "ammonia",
+        "household ammonia",
+        "ammonia water",
+        "ammonical liquor",
+        "ammonia liquor",
+        "aqueous ammonia"
+      ],
+      "functions": [],
+      "description": "Ammonia solution, also known as ammonia water, ammonium hydroxide , ammoniacal liquor, ammonia liquor, aqua ammonia, aqueous ammonia, or -inaccurately- ammonia, is a solution of ammonia in water. It can be denoted by the symbols NH3-aq-.  Although the name ammonium hydroxide suggests an alkali with composition [NH4+][OH−], it is actually impossible to isolate samples of NH4OH. The ions NH4+ and OH− do not account for a significant fraction of the total amount of ammonia except in extremely dilute solutions.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonia_solution",
+      "wikidata": "Q421888"
+    },
+    {
+      "title": "ammonium lactate",
+      "eNumber": "E328",
+      "synonyms": [
+        "E328",
+        "ammonium lactate"
+      ],
+      "functions": [],
+      "description": "Ammonium lactate is a compound with formula NH4-C2H4-OH-COO-. It is the ammonium salt of lactic acid. It has mild anti-bacterial properties. It has E number \"E328\" and is the active ingredient of the skin lotions Amlactin and Lac-Hydrin.Ammonium lactate is a mix of lactic acid and ammonium hydroxide. It is used as a skin moisturizer lotion to treat dry, scaly, itchy skin. Those who are using it should avoid exposure to sunlight or artificial UV rays, such as sunlamps or tanning beds. Ammonium lactate makes skin more sensitive to sunlight. Skin is more likely to sunburn. Use sunblock and wear clothes when exposed to sunlight.[1]",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_lactate",
+      "wikidata": "Q663358"
+    },
+    {
+      "title": "ammonium malate",
+      "eNumber": "E349",
+      "synonyms": [
+        "E349",
+        "ammonium malate"
+      ],
+      "functions": [],
+      "description": "Ammonium malate is a compound with formula NH4-C2H4O-COO-2-. It is the ammonium salt of malic acid.  It is used as a food additive and has the E number E349. There is a recommendation to avoid this food additive.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_malate",
+      "wikidata": "Q4747303"
+    },
+    {
+      "title": "ammonium persulfate",
+      "eNumber": "E923",
+      "synonyms": [
+        "E923",
+        "ammonium persulfate"
+      ],
+      "functions": [],
+      "description": "Ammonium persulfate -APS- is the inorganic compound with the formula -NH4-2S2O8.  It is a colourless -white- salt that is highly soluble in water, much more so than the related potassium salt. It is a strong oxidizing agent that is used in polymer chemistry, as an etchant, and as a cleaning and bleaching agent. The dissolution of the salt in water is an endothermic process.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_persulfate",
+      "wikidata": "Q412085"
+    },
+    {
+      "title": "Ammonium phosphate",
+      "eNumber": "E342",
+      "synonyms": [
+        "E342",
+        "Ammonium phosphate",
+        "monoammonium phosphate",
+        "diammonium phosphate"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967184"
+    },
+    {
+      "title": "Ammonium phosphatides",
+      "eNumber": "E442",
+      "synonyms": [
+        "E442",
+        "Ammonium phosphatides",
+        "Mixed ammonium salts of phosphorylated glycerides",
+        "Emulsifier YN",
+        "Ammonium phosphatide"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "The mix of ammonium salts of phosphorylated glycerides can be either made synthetically or from mixture of glycerol and partially hardened plant -most often used: rapeseed oil- oils.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Mixed_ammonium_salts_of_phosphorylated_glycerides",
+      "wikidata": "Q695975"
+    },
+    {
+      "title": "Ammonium polyphosphate",
+      "eNumber": "E545",
+      "synonyms": [
+        "E545",
+        "Ammonium polyphosphate"
+      ],
+      "functions": [],
+      "description": "Ammonium polyphosphate commercially produced by Clariant, -former business area of Hoechst AG-, Budenheim and other sources is an inorganic salt of polyphosphoric acid and ammonia containing both chains and possibly branching.  Its chemical formula is [NH4 PO3]n-OH-2 showing that each monomer consists of an orthophosphate radical of a phosphorus atom with three oxygens and one negative charge neutralized by an ammonium cation leaving two bonds free to polymerize.  In the branched cases some monomers are missing the ammonium anion and instead link to three other monomers. The properties of ammonium polyphosphate depend on the number of monomers in each molecule and to a degree on how often it branches.  Shorter chains -n<100- are more water sensitive and less thermally stable than longer chains -n>1000-, but short polymer chains -e.g. pyro-, tripoly-, and tetrapoly-- are more soluble and show increasing solubility with increasing chain length.Ammonium polyphosphate can be prepared by reacting concentrated phosphoric acid with ammonia.  However, iron and aluminum impurities, soluble in concentrated phosphoric acid, form gelatinous precipitates or \"sludges\" in ammonium polyphosphate at pH between 5 and 7. Other metal impurities such as copper, chromium, magnesium, and zinc form granular precipitates. However, depending on the degree of polymerization, ammonium polyphosphate can act as a chelating agent to keep certain metal ions dissolved in solution.Ammonium polyphosphate is used as a food additive, emulsifier, -E number: E545- and as a fertilizer. Ammonium polyphosphate -APP- is also used as a flame retardant in many applications such as paints and coatings, and in a variety of polymers: the most important ones are polyolefins, and particularly polypropylene, where APP is part of intumescent systems. Compounding with APP-based flame retardants in polypropylene is described in. Further applications are thermosets, where APP is used in unsaturated polyesters and gel coats -APP blends with synergists-, epoxies and polyurethane castings -intumescent systems-. APP is also applied to flame retard polyurethane foams. Ammonium polyphosphates as used as flame retardants in polymers have long chains and a specific crystallinity -Form II-. They start to decompose at 240 °C to form ammonia and phosphoric acid.  The phosphoric acid acts as an acid catalyst in the dehydration of carbon-based poly-alcohols, such as cellulose in wood.  The phosphoric acid reacts with alcohol groups to form heat-unstable phosphate esters.  The esters decompose to release carbon dioxide and regenerate the phosphoric acid catalyst.  In the gas phase, the release of non-flammable carbon dioxide helps to dilute the oxygen of the air and flammable decomposition products of the material that is burning.  In the condensed phase, the resultant carbonaceous char helps to shield the underlying polymer from attack by oxygen and radiant heat. Use as an intumescent is achieved when combined with starch-based materials such as pentaerythritol and melamine as expanding agents. The mechanisms of intumescence and the mode of action of APP are described in a series of publications.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_polyphosphate",
+      "wikidata": "Q2770473"
+    },
+    {
+      "title": "Ammonium sulphate",
+      "eNumber": "E517",
+      "synonyms": [
+        "E517",
+        "Ammonium sulphate",
+        "ammonium sulfate"
+      ],
+      "functions": [],
+      "description": "Ammonium sulfate -American English and international scientific usage; ammonium sulphate in British English-; -NH4-2SO4, is an inorganic salt with a number of commercial uses. The most common use is as a soil fertilizer. It contains 21% nitrogen and 24% sulfur.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_sulfate",
+      "wikidata": "Q191831"
+    },
+    {
+      "title": "Anionic methacrylate copolymer",
+      "eNumber": "E1207",
+      "synonyms": [
+        "E1207",
+        "Anionic methacrylate copolymer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Annatto",
+      "eNumber": "E160B",
+      "synonyms": [
+        "E160b",
+        "Annatto",
+        "bixin",
+        "norbixin",
+        "roucou",
+        "achiote",
+        "annatto norbixin",
+        "annatto bixin",
+        "Orlean",
+        "Terre orellana",
+        "L. Orange",
+        "CI Natural Orange 4"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q425902"
+    },
+    {
+      "title": "Annatto bixin",
+      "eNumber": "E160BI",
+      "synonyms": [
+        "E160bi",
+        "Annatto bixin",
+        "Bixin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Annatto norbixin",
+      "eNumber": "E160BII",
+      "synonyms": [
+        "E160bii",
+        "Annatto norbixin",
+        "Norbixin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Anoxomer",
+      "eNumber": "E323",
+      "synonyms": [
+        "E323",
+        "Anoxomer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Anthocyanins",
+      "eNumber": "E163",
+      "synonyms": [
+        "E163",
+        "Anthocyanins",
+        "Anthocyanin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Anthocyanins -also anthocyans; from Greek: ἄνθος -anthos- \"flower\" and κυάνεος/κυανοῦς kyaneos/kyanous \"dark blue\"- are water-soluble vacuolar pigments that, depending on their pH, may appear red, purple, or blue. Food plants rich in anthocyanins include the blueberry, raspberry, black rice, and black soybean, among many others that are red, blue, purple, or black. Some of the colors of autumn leaves are derived from anthocyanins.Anthocyanins belong to a parent class of molecules called flavonoids synthesized via the phenylpropanoid pathway. They occur in all tissues of higher plants, including leaves, stems, roots, flowers, and fruits. Anthocyanins are derived from anthocyanidins by adding sugars. They are odorless and moderately astringent. Although approved to color foods and beverages in the European Union, anthocyanins are not approved for use as a food additive because they have not been verified as safe when used as food or supplement ingredients. There is no conclusive evidence anthocyanins have any effect on human biology or diseases.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Anthocyanin",
+      "wikidata": "Q262547"
+    },
+    {
+      "title": "Arabinogalactan",
+      "eNumber": "E409",
+      "synonyms": [
+        "E409",
+        "Arabinogalactan"
+      ],
+      "functions": [],
+      "description": "Arabinogalactan is a biopolymer consisting of arabinose and galactose monosaccharides.  Two classes of arabinogalactans are found in nature: plant arabinogalactan and microbial arabinogalactan.  In plants, it is a major component of many gums, including gum arabic and gum ghatti. It is often found attached to proteins, and the resulting arabinogalactan protein -AGP- functions as both an intercellular signaling molecule and a glue to seal plant wounds.The microbial arabinogalactan is a major structural component of the mycobacterial cell wall.  Both the arabinose and galactose exist solely in the furanose configuration.  The galactan portion of microbial arabinogalactan is linear, consisting of approximately 30 units with alternating β--1-5- and β--1-6- glycosidic linkages. The arabinan chain, which consists of about 30 residues, is attached at three branch points within the galactan chain, believed to be at residues 8, 10 and 12. The arabinan portion of the polymer is a complex branched structure, usually capped with mycolic acids; the arabinan glycosidic linkages are α--1-3-, α--1-5-, and β--1-2-. The mycobacterial arabinogalactan is recognized by a putative immune lectin intelectin present in chordates.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Arabinogalactan",
+      "wikidata": "Q4783458"
+    },
+    {
+      "title": "Argon",
+      "eNumber": "E938",
+      "synonyms": [
+        "E938",
+        "Argon",
+        "element 18"
+      ],
+      "functions": [],
+      "description": "Argon is a chemical element with symbol Ar and atomic number 18. It is in group 18 of the periodic table and is a noble gas. Argon is the third-most abundant gas in the Earth's atmosphere, at 0.934% -9340 ppmv-. It is more than twice as abundant as water vapor -which averages about 4000 ppmv, but varies greatly-, 23 times as abundant as carbon dioxide -400 ppmv-, and more than 500 times as abundant as neon -18 ppmv-. Argon is the most abundant noble gas in Earth's crust, comprising 0.00015% of the crust. Nearly all of the argon in the Earth's atmosphere is radiogenic argon-40, derived from the decay of potassium-40 in the Earth's crust. In the universe, argon-36 is by far the most common argon isotope, as it is the most easily produced by stellar nucleosynthesis in supernovas. The name \"argon\" is derived from the Greek word ἀργόν, neuter singular form of ἀργός meaning \"lazy\" or \"inactive\", as a reference to the fact that the element undergoes almost no chemical reactions. The complete octet -eight electrons- in the outer atomic shell makes argon stable and resistant to bonding with other elements. Its triple point temperature of 83.8058 K is a defining fixed point in the International Temperature Scale of 1990. Argon is produced industrially by the fractional distillation of liquid air. Argon is mostly used as an inert shielding gas in welding and other high-temperature industrial processes where ordinarily unreactive substances become reactive; for example, an argon atmosphere is used in graphite electric furnaces to prevent the graphite from burning. Argon is also used in incandescent, fluorescent lighting, and other gas-discharge tubes. Argon makes a distinctive blue-green gas laser. Argon is also used in fluorescent glow starters.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Argon",
+      "wikidata": "Q696"
+    },
+    {
+      "title": "Ascorbic acid",
+      "eNumber": "E300",
+      "synonyms": [
+        "E300",
+        "Ascorbic acid",
+        "l-ascorbic acid",
+        "Synonyms L-xylo-Ascorbic acid"
+      ],
+      "functions": [
+        "antioxidant",
+        "sequestrant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q193598"
+    },
+    {
+      "title": "Ascorbyl palmitate",
+      "eNumber": "E304I",
+      "synonyms": [
+        "E304i",
+        "Ascorbyl palmitate",
+        "L-Ascorbyl Palmitate"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Ascorbyl palmitate is an ester formed from ascorbic acid and palmitic acid creating a fat-soluble form of vitamin C.  In addition to its use as a source of vitamin C, it is also used as an antioxidant food additive -E number E304-. It is approved for use as a food additive in the EU, the U.S., Canada, Australia, and New Zealand.Ascorbyl palmitate is known to be broken down -through the digestive process- into ascorbic acid and palmitic acid -a saturated fatty acid- before being absorbed into the bloodstream. Ascorbyl palmitate is also marketed as \"vitamin C ester\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ascorbyl_palmitate",
+      "wikidata": "Q424521"
+    },
+    {
+      "title": "Ascorbyl stearate",
+      "eNumber": "E304II",
+      "synonyms": [
+        "E304ii",
+        "Ascorbyl stearate",
+        "E305"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Ascorbyl palmitate is an ester formed from ascorbic acid and palmitic acid creating a fat-soluble form of vitamin C.  In addition to its use as a source of vitamin C, it is also used as an antioxidant food additive -E number E304-. It is approved for use as a food additive in the EU, the U.S., Canada, Australia, and New Zealand.Ascorbyl palmitate is known to be broken down -through the digestive process- into ascorbic acid and palmitic acid -a saturated fatty acid- before being absorbed into the bloodstream. Ascorbyl palmitate is also marketed as \"vitamin C ester\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ascorbyl_palmitate",
+      "wikidata": "Q424521"
+    },
+    {
+      "title": "Aspartame",
+      "eNumber": "E951",
+      "synonyms": [
+        "E951",
+        "Aspartame",
+        "1-Methyl N-L-alpha-aspartyl-L-phenylalanine",
+        "Asp-phe-ome",
+        "3-Amino-N-(alpha-methoxycarbonylphenethyl) succinamic acid",
+        "3-Amino-N-(α-carboxyphenethyl)succinamic acid N-methyl ester",
+        "L-Aspartyl-L-phenylalanine methyl ester",
+        "1-methyl N-L-α-aspartyl-L-phenylalanate",
+        "Aspartylphenylalanine methyl ester",
+        "3-Amino-N-(alpha-carboxyphenethyl)succinamic acid N-methyl ester",
+        "3-Amino-N-(α-methoxycarbonylphenethyl) succinamic acid",
+        "1-Methyl N-L-alpha-aspartyl-L-phenylalanate"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Aspartame -APM- is an artificial non-saccharide sweetener used as a sugar substitute in some foods and beverages. In the European Union, it is codified as E951. Aspartame is a methyl ester of the aspartic acid/phenylalanine dipeptide. A panel of experts set up by the European Food Safety Authority concluded in 2013 that aspartame is safe for human consumption at current levels of exposure. As of  2018, evidence does not support a long-term benefit for weight loss or in diabetes. Because its breakdown products include phenylalanine, people with the genetic condition phenylketonuria -PKU- must be aware of this as an additional source.It was first sold under the brand name NutraSweet. It was first made in 1965, and the patent expired in 1992. It was initially approved for use in food products by the U.S. Food and Drug Administration -FDA- in 1981. The safety of aspartame has been the subject of several political and medical controversies, United States congressional hearings, and Internet hoaxes.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Aspartame",
+      "wikidata": "Q182040"
+    },
+    {
+      "title": "Astaxanthin",
+      "eNumber": "E161J",
+      "synonyms": [
+        "E161j",
+        "Astaxanthin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Azodicarbonamide",
+      "eNumber": "E927A",
+      "synonyms": [
+        "E927a",
+        "Azodicarbonamide"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q415646"
+    },
+    {
+      "title": "Azodicarbonamide and Carbamide",
+      "eNumber": "E927",
+      "synonyms": [
+        "E927",
+        "Azodicarbonamide and Carbamide"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Azorubine",
+      "eNumber": "E122",
+      "synonyms": [
+        "E122",
+        "Azorubine",
+        "carmoisine",
+        "Food Red 3",
+        "Brillantcarmoisin O",
+        "Acid Red 14",
+        "Azorubin S",
+        "C.I. 14720"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Azorubine is an azo dye produced as a disodium salt. In its dry form,  the product appears red to maroon. It is mainly used in foods which are heat-treated after fermentation. It has E number E122.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Azorubine",
+      "wikidata": "Q409676"
+    },
+    {
+      "title": "Bakers yeast glycan",
+      "eNumber": "E408",
+      "synonyms": [
+        "E408",
+        "Bakers yeast glycan"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18935685"
+    },
+    {
+      "title": "Basic methacrylate copolymer",
+      "eNumber": "E1205",
+      "synonyms": [
+        "E1205",
+        "Basic methacrylate copolymer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967186"
+    },
+    {
+      "title": "Beetroot red",
+      "eNumber": "E162",
+      "synonyms": [
+        "E162",
+        "Beetroot red",
+        "betanin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Betanin, or Beetroot Red, is a red glycosidic food dye obtained from beets; its aglycone, obtained by hydrolyzing away the glucose molecule, is betanidin. As a food additive, its E number is E162.  The color of betanin depends on pH; between four and five it is bright bluish-red, becoming blue-violet as the pH increases. Once the pH reaches alkaline levels betanin degrades by hydrolysis, resulting in a yellow-brown color. Betanin is a betalain pigment, together with isobetanin, probetanin, and neobetanin. Other pigments contained in beet are indicaxanthin and vulgaxanthins.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Betanin",
+      "wikidata": "Q420138"
+    },
+    {
+      "title": "Bentonite",
+      "eNumber": "E558",
+      "synonyms": [
+        "E558",
+        "Bentonite"
+      ],
+      "functions": [],
+      "description": "Bentonite -/ˈbɛntənʌɪt/- is an absorbent aluminium phyllosilicate clay consisting mostly of montmorillonite. It was named by Wilbur C. Knight in 1898 after the Cretaceous Benton Shale near Rock River, Wyoming.The different types of bentonite are each named after the respective dominant element, such as potassium -K-, sodium -Na-, calcium -Ca-, and aluminium -Al-. Experts debate a number of nomenclatorial problems with the classification of bentonite clays. Bentonite usually forms from weathering of volcanic ash, most often in the presence of water. However, the term bentonite, as well as a similar clay called tonstein, has been used to describe clay beds of uncertain origin. For industrial purposes, two main classes of bentonite exist: sodium and calcium bentonite. In stratigraphy and tephrochronology, completely devitrified -weathered volcanic glass- ash-fall beds are commonly referred to as K-bentonites when the dominant clay species is illite. In addition to montmorillonite and illite another common clay species that is sometimes dominant is  kaolinite. Kaolinite-dominated clays are commonly referred to as tonsteins and are typically associated with coal.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Bentonite",
+      "wikidata": "Q380149"
+    },
+    {
+      "title": "Benzoic acid",
+      "eNumber": "E210",
+      "synonyms": [
+        "E210",
+        "Benzoic acid"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Benzoic acid , C7H6O2 -or C6H5COOH-, is a colorless crystalline solid and a simple aromatic carboxylic acid. The name is derived from gum benzoin, which was for a long time its only known source. Benzoic acid occurs naturally in many plants and serves as an intermediate in the biosynthesis of many secondary metabolites.  Salts of benzoic acid are used as food preservatives and benzoic acid is an important precursor for the industrial synthesis of many other organic substances.  The salts and esters of benzoic acid are known as benzoates .",
+      "wikipedia": "https://en.wikipedia.org/wiki/Benzoic_acid",
+      "wikidata": "Q191700"
+    },
+    {
+      "title": "Benzoin resin",
+      "eNumber": "E906",
+      "synonyms": [
+        "E906",
+        "Benzoin resin"
+      ],
+      "functions": [],
+      "description": "Benzoin  or benjamin -corrupted pronunciation- is a balsamic resin obtained from the bark of several species of trees in the genus Styrax. It is used in perfumes, some kinds of incense, as a flavoring, and medicine -see tincture of benzoin-. It is distinct from the chemical compound benzoin, which is ultimately derived from benzoin resin; the resin, however, does not contain this compound. Benzoin is sometimes called gum benzoin or gum benjamin, and in India as loban, though loban is, via Arabic lubān, a generic term for frankincense-type incense, e.g., fragrant tree resin. Benzoin is also called storax, not to be confused with the balsam of the same name obtained from the Hamamelidaceae family. Benzoin is a common ingredient in incense-making and perfumery because of its sweet vanilla-like aroma and fixative properties. Gum benzoin is a major component of the type of church incense used in Russia and some other Orthodox Christian societies, as well as Western Catholic Churches. Most benzoin is used in the Arab states of the Persian Gulf and India, where it is burned on charcoal as an incense. It is also used in the production of Bakhoor -Arabic بخور - scented wood chips- as well as various mixed resin incense in the Arab countries and the Horn of Africa. Benzoin is also used in blended types of Japanese incense, Indian incense, Chinese incense -known as Anxi xiang; 安息香-, and Papier d'Arménie as well as incense sticks. There are two common kinds of benzoin, benzoin Siam and benzoin Sumatra. Benzoin Siam is obtained from Styrax tonkinensis, found across Thailand, Laos, Cambodia, and Vietnam. Benzoin Sumatra is obtained from Styrax benzoin, which grows predominantly on the island of Sumatra. Unlike Siamese benzoin, Sumatran benzoin contains cinnamic acid in addition to benzoic acid. In the United States, Sumatra benzoin -Styrax benzoin and Styrax paralleoneurus- is more customarily used in pharmaceutical preparations, Siam benzoin -Styrax tonkinensis et al.- in the flavor and fragrance industries.In perfumery, benzoin is used as a fixative, slowing the dispersion of essential oils and other fragrance materials into the air. Benzoin is used in cosmetics, veterinary medicine, and scented candles. It is used as a flavoring in alcoholic and nonalcoholic beverages, baked goods, chewing gum, frozen dairy, gelatins, puddings, and soft candy.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Benzoin_-resin-",
+      "wikidata": "Q793163"
+    },
+    {
+      "title": "Benzole peroxide",
+      "eNumber": "E928",
+      "synonyms": [
+        "E928",
+        "Benzole peroxide",
+        "benzoyl peroxide"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Benzoyl peroxide -BPO- is a medication and industrial chemical. As a medication it is used to treat mild to moderate acne. For more severe cases it may be used together with other treatments. Some versions come mixed with antibiotics such as clindamycin. Other uses include bleaching flour, hair bleaching, teeth whitening, and textile bleaching. It is also used in the plastic industry.Common side effects are skin irritation, dryness, or peeling. Use in pregnancy is of unclear safety. Benzoyl peroxide is in the peroxide family of chemicals. When used for acne it works by killing bacteria.Benzoyl peroxide was first made in 1905 and came into medical use in the 1930s. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. Benzoyl peroxide is available as a generic medication and over the counter. In the United Kingdom 150 ml of a 10% solution costs the NHS about £4. In the United States a month of treatment costs less than US$25.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Benzoyl_peroxide",
+      "wikidata": "Q411424"
+    },
+    {
+      "title": "Benzyl alcohol",
+      "eNumber": "E1519",
+      "synonyms": [
+        "E1519",
+        "Benzyl alcohol",
+        "Phenylcarbinol",
+        "Phenylmethyl alcohol",
+        "Benzenemethanol"
+      ],
+      "functions": [],
+      "description": "Benzyl alcohol is an aromatic alcohol with the formula C6H5CH2OH. The benzyl group is often abbreviated \"Bn\" -not to be confused with \"Bz\" which is used for benzoyl-, thus benzyl alcohol is denoted as BnOH.  Benzyl alcohol is a colorless liquid with a mild pleasant aromatic odor.  It is a useful solvent due to its polarity, low toxicity, and low vapor pressure. Benzyl alcohol has moderate solubility in water -4 g/100 mL- and is miscible in alcohols and diethyl ether.  The anion produced by deprotonation of the alcohol group is known as benzylate or benzyloxide.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Benzyl_alcohol",
+      "wikidata": "Q52353"
+    },
+    {
+      "title": "Beta-apo-8′-carotenal (c30)",
+      "eNumber": "E160E",
+      "synonyms": [
+        "E160e",
+        "Beta-apo-8′-carotenal (c30)",
+        "Apocarotenal",
+        "Beta-apo-8'-carotenal",
+        "C.I. Food orange 6",
+        "E number 160E",
+        "Trans-beta-apo-8'-carotenal",
+        "C30H40O"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Beta-carotene",
+      "eNumber": "E160AI",
+      "synonyms": [
+        "E160ai",
+        "Beta-carotene"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "β-Carotene is an organic, strongly colored red-orange pigment abundant in plants and fruits. It is a member of the carotenes, which are terpenoids -isoprenoids-, synthesized biochemically from eight isoprene units and thus having 40 carbons. Among the carotenes, β-carotene is distinguished by having beta-rings at both ends of the molecule. β-Carotene is biosynthesized from geranylgeranyl pyrophosphate.β-Carotene is the most common form of carotene in plants. When used as a food coloring, it has the E number E160a. The structure was deduced by Karrer et al. in 1930. In nature, β-carotene is a precursor -inactive form- to vitamin A via the action of beta-carotene 15‚15'-monooxygenase.Isolation of β-carotene from fruits abundant in carotenoids is commonly done using column chromatography. It can also be extracted from the beta-carotene rich algae, Dunaliella salina. The separation of β-carotene from the mixture of other carotenoids is based on the polarity of a compound. β-Carotene is a non-polar compound, so it is separated with a non-polar solvent such as hexane. Being highly conjugated, it is deeply colored, and as a hydrocarbon lacking functional groups, it is very lipophilic.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Beta-Carotene",
+      "wikidata": "Q306135"
+    },
+    {
+      "title": "Beta-carotene from blakeslea trispora",
+      "eNumber": "E160AIII",
+      "synonyms": [
+        "E160aiii",
+        "Beta-carotene from blakeslea trispora"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Beta-cyclodextrine",
+      "eNumber": "E459",
+      "synonyms": [
+        "E459",
+        "Beta-cyclodextrine"
+      ],
+      "functions": [
+        "carrier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Biphenyl",
+      "eNumber": "E230",
+      "synonyms": [
+        "E230",
+        "Biphenyl",
+        "diphenyl",
+        "(C6H5)2"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Biphenyl -or diphenyl or phenylbenzene or 1‚1′-biphenyl or lemonene- is an organic compound that forms colorless  crystals.  Particularly in older literature, compounds containing the functional group consisting of biphenyl less one hydrogen -the site at which it is attached- may use the prefixes xenyl or diphenylyl.It has a distinctively pleasant smell. Biphenyl is an aromatic hydrocarbon with a molecular formula -C6H5-2. It is notable as a starting material for the production of polychlorinated biphenyls -PCBs-, which were once widely used as dielectric fluids and heat transfer agents. Biphenyl is also an intermediate for the production of a host of other organic compounds such as emulsifiers, optical brighteners, crop protection products, and plastics. Biphenyl is insoluble in water, but soluble in typical organic solvents. The biphenyl molecule consists of two connected phenyl rings.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Biphenyl",
+      "wikidata": "Q410915"
+    },
+    {
+      "title": "Black 7984",
+      "eNumber": "E152",
+      "synonyms": [
+        "E152",
+        "Black 7984",
+        "Food Black 2",
+        "carbon black"
+      ],
+      "functions": [],
+      "description": "Carbon black -subtypes are  acetylene black, channel black, furnace black, lamp black and thermal black- is a material produced by the incomplete combustion of heavy petroleum products such as FCC tar, coal tar, ethylene cracking tar, with the addition of a small amount of vegetable oil. Carbon black is a form of paracrystalline carbon that has a high surface-area-to-volume ratio, albeit lower than that of activated carbon. It is dissimilar to soot in its much higher surface-area-to-volume ratio and significantly lower -negligible and non-bioavailable- PAH -polycyclic aromatic hydrocarbon- content. However, carbon black is widely used as a model compound for diesel soot for diesel oxidation experiments. Carbon black is mainly used as a reinforcing filler in tires and other rubber products. In plastics, paints, and inks, carbon black is used as a color pigment.The current International Agency for Research on Cancer -IARC- evaluation is that, \"Carbon black is possibly carcinogenic to humans -Group 2B-\". Short-term exposure to high concentrations of carbon black dust may produce discomfort to the upper respiratory tract, through mechanical irritation.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carbon_black",
+      "wikidata": "Q764245"
+    },
+    {
+      "title": "Black iron oxide",
+      "eNumber": "E172I",
+      "synonyms": [
+        "E172i",
+        "Black iron oxide"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q3045754"
+    },
+    {
+      "title": "Bleached starch",
+      "eNumber": "E1403",
+      "synonyms": [
+        "E1403",
+        "Bleached starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Bone phosphate",
+      "eNumber": "E542",
+      "synonyms": [
+        "E542",
+        "Bone phosphate",
+        "Bone phosphate (Essentiale Calcium Phosphate‚ Tribasic)"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967189"
+    },
+    {
+      "title": "Boric acid",
+      "eNumber": "E284",
+      "synonyms": [
+        "E284",
+        "Boric acid",
+        "Boracic acid",
+        "Orthoboric acid"
+      ],
+      "functions": [],
+      "description": "Boric acid, also called hydrogen borate, boracic acid, orthoboric acid and acidum boricum, is a weak, monobasic Lewis acid of boron, which is often used as an antiseptic, insecticide, flame retardant, neutron absorber, or precursor to other chemical compounds. It has the chemical formula H3BO3 -sometimes written B-OH-3-, and exists in the form of colorless crystals or a white powder that dissolves in water. When occurring as a mineral, it is called sassolite.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Boric_acid",
+      "wikidata": "Q187045"
+    },
+    {
+      "title": "Brilliant black bn",
+      "eNumber": "E151",
+      "synonyms": [
+        "E151",
+        "Brilliant black bn",
+        "black pn",
+        "E 151",
+        "C.I. 28440",
+        "Brilliant Black PN",
+        "Food Black 1",
+        "Naphthol Black",
+        "C.I. Food Brown 1",
+        "Brilliant Black A"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Brilliant Black BN, Brilliant Black PN, Brilliant Black A, Black PN, Food Black 1, Naphthol Black, C.I. Food Black 1, or C.I. 28440, is a synthetic black diazo dye. It is soluble in water. It usually comes as tetrasodium salt. It has the appearance of solid, fine powder or granules. Calcium and potassium salts are allowed as well. When used as a food dye, its E number is E151. It is used in food decorations and coatings, desserts, sweets, ice cream, mustard, red fruit jams, soft drinks, flavored milk drinks, fish paste, lumpfish caviar and other foods.E151 has been banned in the United States, Belgium, Denmark, Germany, Sweden, Austria, Switzerland, Japan, Finland. It is approved in the European Union. It was banned in Norway until 2001 when it was unbanned due to trade relationships with other countries.It is used for staining animal by-products in category 2.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Brilliant_Black_BN",
+      "wikidata": "Q420079"
+    },
+    {
+      "title": "Brilliant blue FCF",
+      "eNumber": "E133",
+      "synonyms": [
+        "E133",
+        "Brilliant blue FCF",
+        "FD&C Blue 1",
+        "FD and C Blue 1",
+        "Blue 1",
+        "fd&c blue no. 1",
+        "Blue 1 lake"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Brilliant Blue FCF -Blue 1- is an organic compound classified as a triarylmethane dye and a blue azo dye, reflecting its chemical structure. Known under various commercial names, it is a colorant for foods and other substances. It is denoted by E number E133 and has a  color index of 42090. It has the appearance of a blue powder. It is soluble in water, and the solution has a maximum absorption at about 628 nanometers.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Brilliant_Blue_FCF",
+      "wikidata": "Q420093"
+    },
+    {
+      "title": "Brominated vegetable oil",
+      "eNumber": "E443",
+      "synonyms": [
+        "E443",
+        "Brominated vegetable oil"
+      ],
+      "functions": [],
+      "description": "Brominated vegetable oil -BVO- is a complex mixture of plant-derived triglycerides that have been reacted to contain atoms of the element bromine bonded to the molecules. Brominated vegetable oil is used primarily to help emulsify citrus-flavored soft drinks, preventing them from separating during distribution. Brominated vegetable oil has been used by the soft drink industry since 1931, generally at a level of about 8 ppm.Careful control of the type of oil used allows bromination of it to produce BVO with a specific density of 1.33 g/mL, which is noticeably greater than that of water -1 g/mL-. As a result, it can be mixed with less-dense flavoring agents such as citrus flavor oil to produce a resulting oil whose density matches that of water or other products. The droplets containing BVO remain suspended in the water rather than separating and floating at the surface.Alternative food additives used for the same purpose include sucrose acetate isobutyrate -SAIB, E444- and glycerol ester of wood rosin -ester gum, E445-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Brominated_vegetable_oil",
+      "wikidata": "Q4164502"
+    },
+    {
+      "title": "Brown FK",
+      "eNumber": "E154",
+      "synonyms": [
+        "E154",
+        "Brown FK",
+        "Kipper Brown"
+      ],
+      "functions": [],
+      "description": "Brown FK, also called Kipper Brown, Chocolate Brown FK, and C.I. Food Brown 1, is a brown mixture of six synthetic azo dyes, with addition of sodium chloride, and/or sodium sulfate. It is very soluble in water. When used as a food dye, its E number is E154.  It was once used in smoked and cured mackerels and other fish and also in some cooked hams and other meats. It gave a \"healthy\" color that did not fade during cooking, nor leach.It is currently not approved for use in the European Union -but was allowed to color kippers to produce orange kippers-, Australia, Austria, Canada, United States, Japan, Switzerland, New Zealand, Norway, and Russia.In 2011, a review by the European Food Safety Authority concluded that Brown FK was no longer used and the Authority could not conclude on the safety of the substance due to the deficiencies in the available toxicity data. Therefore, it should not be included in the Union list of approved food additives.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Brown_FK",
+      "wikidata": "Q425437"
+    },
+    {
+      "title": "Brown ht",
+      "eNumber": "E155",
+      "synonyms": [
+        "E155",
+        "Brown ht",
+        "Chocolate brown HT"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Brown HT, also called Chocolate Brown HT, Food Brown 3, and C.I. 20285, is a brown synthetic coal tar diazo dye. When used as a food dye, its E number is E155. It is used to substitute cocoa or caramel as a colorant. It is used mainly in chocolate cakes, but also in milk and cheeses, yogurts, jams, fruit products, fish, and other products. It may provoke allergic reactions in asthmatics, people sensitive to aspirin, and other sensitive individuals, and may induce skin sensitivity.It is one of the food colorings that the Hyperactive Children's Support Group recommends be eliminated from the diet of children. It is banned in Austria, Belgium, Denmark, France, Germany, United States, Norway, Switzerland, and Sweden.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Brown_HT",
+      "wikidata": "Q424541"
+    },
+    {
+      "title": "Buffered vinegar",
+      "eNumber": "E267",
+      "synonyms": [
+        "E267",
+        "Buffered vinegar"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q130547560"
+    },
+    {
+      "title": "Butane",
+      "eNumber": "E943A",
+      "synonyms": [
+        "E943a",
+        "Butane"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Butylated hydroxyanisole (bha)",
+      "eNumber": "E320",
+      "synonyms": [
+        "E320",
+        "Butylated hydroxyanisole (bha)",
+        "Butylated hydroxyanisole",
+        "BHA"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Butylated hydroxyanisole -BHA- is an antioxidant consisting of a mixture of two isomeric organic compounds, 2-tert-butyl-4-hydroxyanisole and 3-tert-butyl-4-hydroxyanisole.  It is prepared from 4-methoxyphenol and isobutylene. It is a waxy solid used as a food additive with the E number E320. The primary use for BHA is as an antioxidant and preservative in food, food packaging, animal feed, cosmetics, rubber, and petroleum products. BHA also is commonly used in medicines, such as isotretinoin, lovastatin, and simvastatin, among others.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Butylated_hydroxyanisole",
+      "wikidata": "Q409401"
+    },
+    {
+      "title": "Butylated hydroxytoluene",
+      "eNumber": "E321",
+      "synonyms": [
+        "E321",
+        "Butylated hydroxytoluene",
+        "BHT",
+        "2‚6-Ditertiary-butyl-p-cresol",
+        "bht added to preserve freshness"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Butylated hydroxytoluene -BHT-, also known as dibutylhydroxytoluene, is a lipophilic organic compound, chemically a derivative of phenol, that is useful for its antioxidant properties. European and U.S. regulations allow small amounts to be used as a food additive. In addition to this use, BHT is widely used to prevent oxidation in fluids -e.g. fuel, oil- and other materials where free radicals must be controlled.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Butylated_hydroxytoluene",
+      "wikidata": "Q221945"
+    },
+    {
+      "title": "Calcium 5'-ribonucleotide",
+      "eNumber": "E634",
+      "synonyms": [
+        "E634",
+        "Calcium 5'-ribonucleotide",
+        "Calcium 5'-ribonucleotides"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967192"
+    },
+    {
+      "title": "Calcium acetate",
+      "eNumber": "E263",
+      "synonyms": [
+        "E263",
+        "Calcium acetate"
+      ],
+      "functions": [
+        "preservative",
+        "stabiliser"
+      ],
+      "description": "Calcium acetate is a chemical compound which is a calcium salt of acetic acid. It has the formula Ca-C2H3O2-2. Its standard name is calcium acetate, while calcium ethanoate is the systematic name. An older name is acetate of lime.  The anhydrous form is very hygroscopic; therefore the monohydrate -Ca-CH3COO-2•H2O- is the common form.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_acetate",
+      "wikidata": "Q409251"
+    },
+    {
+      "title": "Calcium alginate",
+      "eNumber": "E404",
+      "synonyms": [
+        "E404",
+        "Calcium alginate"
+      ],
+      "functions": [
+        "carrier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Calcium alginate is a water-insoluble, gelatinous, cream-coloured substance that can be created through the addition of aqueous calcium chloride to aqueous sodium alginate. Calcium alginate is also used for entrapment of enzymes and forming artificial seeds in plant tissue culture. \"Alginate\" is usually the salts of alginic acid, but it can also refer to derivatives of alginic acid and alginic acid itself; in some publications the term \"algin\" is used instead of alginate. Alginate is present in the cell walls of brown algae, as the calcium, magnesium and sodium salts of alginic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_alginate",
+      "wikidata": "Q2034064"
+    },
+    {
+      "title": "Calcium aluminium silicate",
+      "eNumber": "E556",
+      "synonyms": [
+        "E556",
+        "Calcium aluminium silicate",
+        "Calcium aluminosilicate",
+        "Calcium silicoaluminate",
+        "Aluminium calcium silicate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967182"
+    },
+    {
+      "title": "Calcium ascorbate",
+      "eNumber": "E302",
+      "synonyms": [
+        "E302",
+        "Calcium ascorbate"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Calcium ascorbate is a compound with the molecular formula CaC12H14O12. It is the calcium salt of ascorbic acid, one of the mineral ascorbates. It is approximately 10% calcium by mass. As a food additive, it has the E number E 302. It is approved for use as a food additive in the EU, USA and Australia and New Zealand.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_ascorbate",
+      "wikidata": "Q283033"
+    },
+    {
+      "title": "Calcium benzoate",
+      "eNumber": "E213",
+      "synonyms": [
+        "E213",
+        "Calcium benzoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Calcium benzoate refers to the calcium salt of benzoic acid. When used in the food industry as a preservative, its E number is E213 -INS number 213-; it is approved for use as a food additive in the EU, USA and Australia and New Zealand.The formulas and structures of calcium carboxylate derivatives of calcium and related metals are complex. Generally the coordination number is eight and the carboxylates form Ca-O bonds. Another variable is the degree of hydration.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_benzoate",
+      "wikidata": "Q414509"
+    },
+    {
+      "title": "Calcium bisulphite",
+      "eNumber": "E227",
+      "synonyms": [
+        "E227",
+        "Calcium bisulphite",
+        "Calcium bisulfite"
+      ],
+      "functions": [],
+      "description": "Calcium bisulfite -calcium bisulphite- is an inorganic compound which is the salt of a calcium cation and a bisulfite anion. It may be prepared by reacting lime with an excess of sulfurous acid, essentially a mixture of sulfur dioxide and water. It is a weak reducing agent, as is sulfur dioxide, sulfites, and any other compound containing sulfur in the +4 oxidation state. As a food additive it is used as a preservative under the E number E227.  Calcium bisulfite is an acid salt and behaves like an acid in aqueous solution.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_bisulfite",
+      "wikidata": "Q419619"
+    },
+    {
+      "title": "Calcium carbonate",
+      "eNumber": "E170I",
+      "synonyms": [
+        "E170i",
+        "Calcium carbonate",
+        "CI Pigment White 18",
+        "Chalk"
+      ],
+      "functions": [
+        "colour",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_carbonate",
+      "wikidata": "Q23767"
+    },
+    {
+      "title": "Calcium carbonates",
+      "eNumber": "E170",
+      "synonyms": [
+        "E170",
+        "Calcium carbonates"
+      ],
+      "functions": [],
+      "description": "Calcium carbonate is a chemical compound with the formula CaCO3. It is a common substance found in rocks as the minerals calcite and aragonite -most notably as limestone, which is a type of sedimentary rock consisting mainly of calcite- and is the main component of pearls and the shells of marine organisms, snails, and eggs. Calcium carbonate is the active ingredient in agricultural lime and is created when calcium ions in hard water react with carbonate ions to create limescale. It is medicinally used as a calcium supplement or as an antacid, but excessive consumption can be hazardous.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_carbonate",
+      "wikidata": ""
+    },
+    {
+      "title": "Calcium chloride",
+      "eNumber": "E509",
+      "synonyms": [
+        "E509",
+        "Calcium chloride"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener",
+        "coagulant"
+      ],
+      "description": "Calcium chloride is an inorganic compound, a salt with the chemical formula CaCl2.  It is a colorless crystalline solid at room temperature, highly soluble in water. Calcium chloride is commonly encountered as a hydrated solid with generic formula CaCl2-H2O-x, where x = 0, 1, 2, 4, and 6.  These compounds are mainly used for de-icing and dust control. Because the anhydrous salt is hygroscopic, it is used as a desiccant.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_chloride",
+      "wikidata": "Q208451"
+    },
+    {
+      "title": "Calcium citrates",
+      "eNumber": "E333",
+      "synonyms": [
+        "E333",
+        "Calcium citrates",
+        "Calcium citrate",
+        "Calcium salts of citric acid"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Calcium citrate is the calcium salt of citric acid.  It is commonly used as a food additive -E333-, usually as a preservative, but sometimes for flavor.  In this sense, it is similar to sodium citrate.   Calcium citrate is also found in some dietary calcium supplements -e.g. Citracal-. Calcium makes up 24.1% of calcium citrate -anhydrous- and 21.1% of calcium citrate -tetrahydrate- by mass. The tetrahydrate occurs in nature as the mineral Earlandite.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_citrate",
+      "wikidata": "Q420280"
+    },
+    {
+      "title": "Calcium diglutamate",
+      "eNumber": "E623",
+      "synonyms": [
+        "E623",
+        "Calcium diglutamate"
+      ],
+      "functions": [],
+      "description": "Calcium diglutamate, sometimes abbreviated CDG and also called calcium glutamate, is a compound with formula Ca-C5H8NO4-2. It is a calcium acid salt of glutamic acid. CDG is a flavor enhancer -E number E623- — it is the calcium analog of monosodium glutamate -MSG-. Because the glutamate is the actual flavor-enahancer, CDG has the same flavor-enhancing properties as MSG, but without the increased sodium content. As a soluble source of calcium ions, this chemical is also used as a first-aid treatment for exposure to hydrofluoric acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_diglutamate",
+      "wikidata": "Q591440"
+    },
+    {
+      "title": "Calcium dihydrogen diphosphate",
+      "eNumber": "E450VII",
+      "synonyms": [
+        "E450vii",
+        "Calcium dihydrogen diphosphate",
+        "Acid calcium pyrophosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q290828"
+    },
+    {
+      "title": "Calcium disodium ethylenediaminetetraacetate",
+      "eNumber": "E385",
+      "synonyms": [
+        "E385",
+        "Calcium disodium ethylenediaminetetraacetate",
+        "Calcium disodium EDTA",
+        "Calcium disodium ethylene diamine tetra-acetate",
+        "calcium disodium EDTA",
+        "calcium-dinatrium-EDTA",
+        "E-385",
+        "E 385"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative",
+        "sequestrant"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethylenediaminetetraacetic_acid",
+      "wikidata": "Q9189390"
+    },
+    {
+      "title": "Calcium Disulphite",
+      "eNumber": "E225",
+      "synonyms": [
+        "E225",
+        "Calcium Disulphite",
+        "Calcium Disulfite",
+        "Calcium Pyrosulphite",
+        "Calcium Pyrosulfite",
+        "Potassium sulfite",
+        "Potassium sulphite"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative"
+      ],
+      "description": "Potassium sulfite -K2SO3- is a chemical compound which is the salt of potassium cation and sulfite anion.  As a food additive it is used as a preservative under the E number E225 -INS number 225-. It is approved for use in Australia and New Zealand and is not approved in the EU or US.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_sulfite",
+      "wikidata": "Q417109"
+    },
+    {
+      "title": "Calcium erythorbin",
+      "eNumber": "E318",
+      "synonyms": [
+        "E318",
+        "Calcium erythorbin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081784"
+    },
+    {
+      "title": "Calcium ferrocyanide",
+      "eNumber": "E538",
+      "synonyms": [
+        "E538",
+        "Calcium ferrocyanide",
+        "Yellow prussiate of lime"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967196"
+    },
+    {
+      "title": "Calcium formiate",
+      "eNumber": "E238",
+      "synonyms": [
+        "E238",
+        "Calcium formiate",
+        "calcium formate"
+      ],
+      "functions": [],
+      "description": "Calcium formate, Ca-HCO2-2 -or. Ca-HCOO-2-, is the calcium salt of formic acid, HCOOH. It is also known as food additive E238 in food industry. The mineral form is very rare and called formicaite. It is known from a few boron deposits. It may be produced synthetically by reacting calcium oxide or calcium hydroxide with formic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_formate",
+      "wikidata": "Q221123"
+    },
+    {
+      "title": "Calcium fumarate",
+      "eNumber": "E367",
+      "synonyms": [
+        "E367",
+        "Calcium fumarate"
+      ],
+      "functions": [],
+      "description": "Calcium fumarate is a compound with formula Ca-C2H2-COO-2- or -OOC-CH=CH-COO-Ca. It is a calcium salt of fumaric acid, and has been used to enrich foods to boost calcium absorption.It has E number \"E367\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_fumarate",
+      "wikidata": "Q836445"
+    },
+    {
+      "title": "calcium gluconate",
+      "eNumber": "E578",
+      "synonyms": [
+        "E578",
+        "calcium gluconate"
+      ],
+      "functions": [
+        "sequestrant"
+      ],
+      "description": "Calcium gluconate is a mineral supplement and medication. As a medication it is used by injection into a vein to treat low blood calcium, high blood potassium, and magnesium toxicity. Supplementation is generally only required when there is not enough calcium in the diet. Supplementation may be done to treat or prevent osteoporosis or rickets. It can also be taken by mouth but is not recommended for injection into a muscle.Side effects when injected include slow heart rate, pain at the site of injection, and low blood pressure. When taken by mouth side effects may include constipation and nausea. Blood calcium levels should be measured when used and extra care should be taken in those with a history of kidney stones. At normal doses use is regarded as safe in pregnancy and breastfeeding. Calcium gluconate is made by mixing gluconic acid with calcium carbonate or calcium hydroxide.Calcium gluconate came into medical use in the 1920s. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. Calcium gluconate is available as a generic medication. The wholesale cost in the developing world is about 0.21 to 1.34 USD per one gram vial, 10 ml of 100 mg/ml -10% solution-. In the United Kingdom this amount costs the NHS about 0.65 pounds.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_gluconate",
+      "wikidata": "Q413739"
+    },
+    {
+      "title": "calcium glycerophosphate",
+      "eNumber": "E383",
+      "synonyms": [
+        "E383",
+        "calcium glycerophosphate"
+      ],
+      "functions": [],
+      "description": "Calcium glycerylphosphate -or calcium glycerophosphate- is a mineral supplement.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_glycerylphosphate",
+      "wikidata": "Q4119838"
+    },
+    {
+      "title": "Calcium guanylate",
+      "eNumber": "E629",
+      "synonyms": [
+        "E629",
+        "Calcium guanylate"
+      ],
+      "functions": [],
+      "description": "Calcium guanylate is a compound with formula Ca-C10H12O4N5PO4-. It is the calcium salt of guanylic acid. As a food additive, it is used as a flavor enhancer and has the E number E629.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_guanylate",
+      "wikidata": "Q5018832"
+    },
+    {
+      "title": "Calcium hydrogen carbonate",
+      "eNumber": "E170II",
+      "synonyms": [
+        "E170ii",
+        "Calcium hydrogen carbonate",
+        "Calcium bicarbonate",
+        "Calcium acid carbonate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q415144"
+    },
+    {
+      "title": "Calcium hydroxide",
+      "eNumber": "E526",
+      "synonyms": [
+        "E526",
+        "Calcium hydroxide",
+        "Slaked lime"
+      ],
+      "functions": [],
+      "description": "Calcium hydroxide -traditionally called slaked lime- is an inorganic compound with the chemical formula Ca-OH-2. It is a colorless crystal or white powder and is obtained when calcium oxide -called lime or quicklime- is mixed, or slaked with water. It has many names including hydrated lime, caustic lime, builders' lime, slack lime, cal, or pickling lime. Calcium hydroxide is used in many applications, including food preparation. Limewater is the common name for a saturated solution of calcium hydroxide.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_hydroxide",
+      "wikidata": "Q182849"
+    },
+    {
+      "title": "Calcium inosinate",
+      "eNumber": "E633",
+      "synonyms": [
+        "E633",
+        "Calcium inosinate"
+      ],
+      "functions": [],
+      "description": "Calcium inosinate is a calcium salt of the nucleoside inosine.  Under the E number E633, it is a food additive used as a flavor enhancer.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_inosinate",
+      "wikidata": "Q725037"
+    },
+    {
+      "title": "Calcium iodate",
+      "eNumber": "E916",
+      "synonyms": [
+        "E916",
+        "Calcium iodate"
+      ],
+      "functions": [],
+      "description": "Calcium iodates are  inorganic compound composed of calcium and iodate anion. Two forms are known, anhydrous Ca-IO3-2 and the hexahydrate Ca-IO3-2-H2O-. Both are colourless salts that occur naturally as the minerals called lautarite and bruggenite, respectively.  A third mineral form of calcium iodate is dietzeite, a salt containing chromate with the formula Ca2-IO3-2CrO4.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_iodate",
+      "wikidata": "Q2185998"
+    },
+    {
+      "title": "calcium lactate",
+      "eNumber": "E327",
+      "synonyms": [
+        "E327",
+        "calcium lactate"
+      ],
+      "functions": [
+        "thickener"
+      ],
+      "description": "Calcium lactate is a white crystalline salt with formula C6H10CaO6, consisting of two lactate anions H3C-CHOH-CO−2 for each calcium cation Ca2+.  It forms several hydrates, the most common being the pentahydrate C6H10CaO6·5H2O. Calcium lactate is used in medicine, mainly to treat calcium deficiencies; and as a food additive with E number of E327.  Some cheese crystals consist of calcium lactate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_lactate",
+      "wikidata": "Q419693"
+    },
+    {
+      "title": "Calcium lactobionate",
+      "eNumber": "E399",
+      "synonyms": [
+        "E399",
+        "Calcium lactobionate"
+      ],
+      "functions": [],
+      "description": "Lactobionic acid -4-O-β-galactopyranosyl-D-gluconic acid- is a sugar acid.  It is a disaccharide formed from gluconic acid and galactose.  It can be formed by oxidation of lactose.  The carboxylate anion of lactobionic acid is known as lactobionate. As an acid, lactobionic acid can form salts with mineral cations such as calcium, potassium, sodium and zinc.  Calcium lactobionate is a food additive used as a stabilizer. Potassium lactobionate is added to organ preservation solutions such as Viaspan or CoStorSol to provide osmotic support and prevent cell swelling. Mineral salts of lactobionic acid are also used for mineral supplementation. Lactobionic acid is also used in the cosmetics industry as an antioxidant and in the pharmaceutical industry as an excipient for formulation. For example, the antibiotic erythromycin is used as the salt erythromycin lactobionate when intravenously delivered.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lactobionic_acid",
+      "wikidata": "Q6138969"
+    },
+    {
+      "title": "Calcium malate",
+      "eNumber": "E352I",
+      "synonyms": [
+        "E352i",
+        "Calcium malate"
+      ],
+      "functions": [],
+      "description": "Calcium malate is a compound with formula Ca-C2H4O-COO-2-. It is the calcium salt of malic acid.  As a food additive, it has the E number E352. It is related to, but different from, calcium citrate malate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_malate",
+      "wikidata": "Q1356722"
+    },
+    {
+      "title": "Calcium malates",
+      "eNumber": "E352",
+      "synonyms": [
+        "E352",
+        "Calcium malates"
+      ],
+      "functions": [],
+      "description": "Calcium malate is a compound with formula Ca-C2H4O-COO-2-. It is the calcium salt of malic acid.  As a food additive, it has the E number E352. It is related to, but different from, calcium citrate malate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_malate",
+      "wikidata": "Q1356722"
+    },
+    {
+      "title": "Calcium oxide",
+      "eNumber": "E529",
+      "synonyms": [
+        "E529",
+        "Calcium oxide"
+      ],
+      "functions": [],
+      "description": "Calcium oxide -CaO-, commonly known as quicklime or burnt lime, is a widely used chemical compound. It is a white, caustic, alkaline, crystalline solid at room temperature. The broadly used term lime connotes calcium-containing inorganic materials, in which carbonates, oxides and hydroxides of calcium, silicon, magnesium, aluminium, and iron predominate. By contrast, quicklime  specifically applies to the single chemical compound calcium oxide. Calcium oxide that survives processing without reacting in building products such as cement is called free lime.Quicklime is relatively inexpensive. Both it and a chemical derivative -calcium hydroxide, of which quicklime is the base anhydride- are important commodity chemicals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_oxide",
+      "wikidata": "Q185006"
+    },
+    {
+      "title": "calcium peroxide",
+      "eNumber": "E930",
+      "synonyms": [
+        "E930",
+        "calcium peroxide"
+      ],
+      "functions": [],
+      "description": "Calcium peroxide or calcium dioxide is the inorganic compound with the formula CaO2. It is the peroxide -O22−- salt of Ca2+. Commercial samples can be yellowish, but the pure compound is white.  It is almost insoluble in water.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_peroxide",
+      "wikidata": "Q94770"
+    },
+    {
+      "title": "Calcium phosphates",
+      "eNumber": "E341",
+      "synonyms": [
+        "E341",
+        "Calcium phosphates",
+        "calcium phosphate",
+        "calcium phosphates",
+        "E 341",
+        "E-341"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Calcium phosphate is a family of materials and minerals containing calcium ions -Ca2+- together with inorganic phosphate anions.  Some so-called calcium phosphates contain oxide and hydroxide as well.  They are white solids of nutritious value.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_phosphate",
+      "wikidata": "Q426664"
+    },
+    {
+      "title": "Calcium polyphosphate",
+      "eNumber": "E452IV",
+      "synonyms": [
+        "E452iv",
+        "Calcium polyphosphate",
+        "Calcium metaphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q11867365"
+    },
+    {
+      "title": "Calcium polyphosphate",
+      "eNumber": "E544",
+      "synonyms": [
+        "E544",
+        "Calcium polyphosphate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967198"
+    },
+    {
+      "title": "calcium propionate",
+      "eNumber": "E282",
+      "synonyms": [
+        "E282",
+        "calcium propionate",
+        "calcium propanoate",
+        "cal. pro.",
+        "cal.pro."
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Calcium propanoate or calcium propionate has the formula Ca-C2H5COO-2. It is the calcium salt of propanoic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_propanoate",
+      "wikidata": "Q417394"
+    },
+    {
+      "title": "Calcium salts of fatty acids",
+      "eNumber": "E470AIII",
+      "synonyms": [
+        "E470aiii",
+        "Calcium salts of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Calcium silicate",
+      "eNumber": "E552",
+      "synonyms": [
+        "E552",
+        "Calcium silicate"
+      ],
+      "functions": [],
+      "description": "Calcium silicate is the chemical compound Ca2SiO4, also known as calcium orthosilicate and is sometimes formulated as 2CaO·SiO2. It is also referred to by the shortened trade name Cal-Sil or Calsil.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_silicate",
+      "wikidata": "Q416365"
+    },
+    {
+      "title": "Calcium sorbate",
+      "eNumber": "E203",
+      "synonyms": [
+        "E203",
+        "Calcium sorbate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Calcium sorbate is the calcium salt of sorbic acid. Calcium sorbate is a polyunsaturated fatty acid salt.  It is a commonly used food preservative; its E number is E203.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_sorbate",
+      "wikidata": "Q425183"
+    },
+    {
+      "title": "Calcium stearoyl fumarate",
+      "eNumber": "E486",
+      "synonyms": [
+        "E486",
+        "Calcium stearoyl fumarate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18606662"
+    },
+    {
+      "title": "Calcium stearoyl-2-lactylate",
+      "eNumber": "E482",
+      "synonyms": [
+        "E482",
+        "Calcium stearoyl-2-lactylate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Calcium stearoyl-2-lactylate -calcium stearoyl lactylate or CSL- or E482 is a versatile,  FDA approved food additive.  It is one type of a commercially available lactylate.  CSL is  non-toxic,  biodegradable, and typically manufactured using  biorenewable  feedstocks.  Because CSL is a safe and highly effective food additive, it is used in a wide variety of products from  baked goods and  desserts to packaging.As described by the  Food Chemicals Codex 7th edition, CSL is a cream-colored powder.  CSL is currently manufactured by the esterification of stearic acid and lactic acid with partial neutralization using food-grade hydrated lime -calcium hydroxide-.  Commercial grade CSL is a mixture of calcium salts of stearoyl lactic acid, with minor proportions of other salts of related acids.  The  HLB for CSL is 5.1.  It is slightly soluble in hot water.  The pH of a 2% aqueous suspension is approximately 4.7.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_stearoyl-2-lactylate",
+      "wikidata": "Q788535"
+    },
+    {
+      "title": "Calcium sulphate",
+      "eNumber": "E516",
+      "synonyms": [
+        "E516",
+        "Calcium sulphate",
+        "Gypsum",
+        "Selenite",
+        "Calcium sulfate",
+        "calcium sulfate added to prevent caking"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Calcium sulfate -or calcium sulphate- is the inorganic compound with the formula CaSO4 and related hydrates. In the form of γ-anhydrite -the anhydrous form-, it is used as a desiccant. One particular hydrate is better known as plaster of Paris, and another occurs naturally as the mineral gypsum.  It has many uses in industry. All forms are white solids that are poorly soluble in water. Calcium sulfate causes permanent hardness in water.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_sulfate",
+      "wikidata": "Q407258"
+    },
+    {
+      "title": "Calcium sulphite",
+      "eNumber": "E226",
+      "synonyms": [
+        "E226",
+        "Calcium sulphite",
+        "Calcium sulfite"
+      ],
+      "functions": [],
+      "description": "Calcium sulfite, or calcium sulphite, is a chemical compound, the calcium salt of sulfite with the formula CaSO3·x-H2O-. Two crystalline forms are known, the hemihydrate and the tetrahydrate, respectively CaSO3·½-H2O- and CaSO3·4-H2O-. All forms are white solids.  It is most notable as the product of flue-gas desulfurization.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_sulfite",
+      "wikidata": "Q899410"
+    },
+    {
+      "title": "Calcium tartrate",
+      "eNumber": "E354",
+      "synonyms": [
+        "E354",
+        "Calcium tartrate"
+      ],
+      "functions": [],
+      "description": "Calcium tartrate, exactly calcium L-tartrate, is a byproduct of the wine industry, prepared from wine fermentation dregs. It is the calcium salt of  L-tartaric acid, an acid most commonly found in grapes. Its solubility decreases with lower temperature, which results in the forming of whitish -in red wine often reddish- crystalline  clusters as it precipitates. It finds use as a food preservative and acidity regulator. Like tartaric acid, calcium tartrate has two asymmetric carbons, hence it has two chiral isomers and a non-chiral isomer -meso-form-. Most calcium tartrate of biological origin is the chiral levorotatory -–- isomer.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_tartrate",
+      "wikidata": "Q416767"
+    },
+    {
+      "title": "Candelilla wax",
+      "eNumber": "E902",
+      "synonyms": [
+        "E902",
+        "Candelilla wax"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "thickener"
+      ],
+      "description": "Candelilla wax is a wax derived from the leaves of the small Candelilla shrub native to northern Mexico and the southwestern United States, Euphorbia cerifera and Euphorbia antisyphilitica, from the family Euphorbiaceae. It is yellowish-brown, hard, brittle, aromatic, and opaque to translucent.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Candelilla_wax",
+      "wikidata": "Q898937"
+    },
+    {
+      "title": "Canthaxanthin",
+      "eNumber": "E161G",
+      "synonyms": [
+        "E161g",
+        "Canthaxanthin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Caramel",
+      "eNumber": "E150",
+      "synonyms": [
+        "E150",
+        "Caramel"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Caramel",
+      "wikidata": "Q183440"
+    },
+    {
+      "title": "Carbamide",
+      "eNumber": "E927B",
+      "synonyms": [
+        "E927b",
+        "Carbamide",
+        "urea"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q48318"
+    },
+    {
+      "title": "Carbomer",
+      "eNumber": "E1210",
+      "synonyms": [
+        "E1210",
+        "Carbomer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Carbon dioxide",
+      "eNumber": "E290",
+      "synonyms": [
+        "E290",
+        "Carbon dioxide",
+        "Carbonic acid gas"
+      ],
+      "functions": [
+        "preservative",
+        "propellent-gas"
+      ],
+      "description": "Carbon dioxide -chemical formula CO2- is a colorless gas with a density about 60% higher than that of dry air.  Carbon dioxide consists of a carbon atom covalently double bonded to two oxygen atoms. It occurs naturally in Earth's atmosphere as a trace gas. The current concentration is about 0.04% -410 ppm- by volume, having risen from pre-industrial levels of 280 ppm.  Natural sources include volcanoes, hot springs and geysers, and it is freed from carbonate rocks by dissolution in water and acids. Because carbon dioxide is soluble in water, it occurs naturally in groundwater, rivers and lakes, ice caps, glaciers and seawater. It is present in deposits of petroleum and natural gas. Carbon dioxide is odorless at normally encountered concentrations, however, at high concentrations, it has a sharp and acidic odor.As the source of available carbon in the carbon cycle, atmospheric carbon dioxide is the primary carbon source for life on Earth and its concentration in Earth's pre-industrial atmosphere since late in the Precambrian has been regulated by photosynthetic organisms and geological phenomena. Plants, algae and cyanobacteria use light energy to photosynthesize carbohydrate from carbon dioxide and water, with oxygen produced as a waste product.CO2 is produced by all aerobic organisms when they metabolize carbohydrates and lipids to produce energy by respiration. It is returned to water via the gills of fish and to the air via the lungs of air-breathing land animals, including humans. Carbon dioxide is produced during the processes of decay of organic materials and the fermentation of sugars in bread, beer and wine making. It is produced by combustion of wood and other organic materials and fossil fuels such as coal, peat, petroleum and natural gas. It is an unwanted byproduct in many large scale oxidation processes, for example, in the production of acrylic acid -over 5 million tons/year-.It is a versatile industrial material, used, for example, as an inert gas in welding and fire extinguishers, as a pressurizing gas in air guns and oil recovery, as a chemical feedstock and as a supercritical fluid solvent in decaffeination of coffee and supercritical drying. It is added to drinking water and carbonated beverages including beer and sparkling wine to add effervescence. The frozen solid form of CO2, known as dry ice is used as a refrigerant and as an abrasive in dry-ice blasting. Carbon dioxide is the most significant long-lived greenhouse gas in Earth's atmosphere. Since the Industrial Revolution anthropogenic emissions – primarily from use of fossil fuels and deforestation – have rapidly increased its concentration in the atmosphere, leading to global warming.  Carbon dioxide also causes ocean acidification because it dissolves in water to form carbonic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carbon_dioxide",
+      "wikidata": "Q1997"
+    },
+    {
+      "title": "Carbonat Acid De Sodi I Difosfat De Disodi",
+      "eNumber": "",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Carbonates",
+      "eNumber": "E502",
+      "synonyms": [
+        "E502",
+        "Carbonates"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Carnauba wax",
+      "eNumber": "E903",
+      "synonyms": [
+        "E903",
+        "Carnauba wax",
+        "carnauba wax coating agents"
+      ],
+      "functions": [
+        "carrier"
+      ],
+      "description": "Carnauba -; Portuguese: carnaúba [kaʁnɐˈubɐ]-, also called Brazil wax and palm wax, is a wax of the leaves of the palm Copernicia prunifera -Synonym: Copernicia cerifera-, a plant native to and grown only in the northeastern Brazilian states of Piauí, Ceará, Maranhão, Bahia, and Rio Grande do Norte. It is known as \"queen of waxes\" and in its pure state, usually comes in the form of hard yellow-brown flakes. It is obtained from the leaves of the carnauba palm by collecting and drying them, beating them to loosen the wax, then refining and bleaching the wax.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carnauba_wax",
+      "wikidata": "Q839494"
+    },
+    {
+      "title": "carotene",
+      "eNumber": "E160A",
+      "synonyms": [
+        "E160a",
+        "carotene"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "The term carotene -also carotin, from the Latin carota, \"carrot\"- is used for many related unsaturated hydrocarbon substances having the formula C40Hx, which are synthesized by plants but in general cannot be made by animals -with the exception of some aphids and spider mites which acquired the synthesizing genes from fungi-. Carotenes are photosynthetic pigments important for photosynthesis. Carotenes contain no oxygen atoms. They absorb ultraviolet, violet, and blue light and scatter orange or red light, and -in low concentrations- yellow light. Carotenes are responsible for the orange colour of the carrot, for which this class of chemicals is named, and for the colours of many other fruits, vegetables and fungi -for example, sweet potatoes, chanterelle and orange cantaloupe melon-. Carotenes are also responsible for the orange -but not all of the yellow- colours in dry foliage. They also -in lower concentrations- impart the yellow coloration to milk-fat and butter. Omnivorous animal species which are relatively poor converters of coloured dietary carotenoids to colourless retinoids have yellowed-coloured body fat, as a result of the carotenoid retention from the vegetable portion of their diet. The typical yellow-coloured fat of humans and chickens is a result of fat storage of carotenes from their diets. Carotenes contribute to photosynthesis by transmitting the light energy they absorb to chlorophyll. They also protect plant tissues by helping to absorb the energy from singlet oxygen, an excited form of the oxygen molecule O2 which is formed during photosynthesis. β-Carotene is composed of two retinyl groups, and is broken down in the mucosa of the human small intestine by β-carotene 15‚15'-monooxygenase to retinal, a form of vitamin A. β-Carotene can be stored in the liver and body fat and converted to retinal as needed, thus making it a form of vitamin A for humans and some other mammals. The carotenes α-carotene and γ-carotene, due to their single retinyl group -β-ionone ring-, also have some vitamin A activity -though less than β-carotene-, as does the xanthophyll carotenoid β-cryptoxanthin. All other carotenoids, including lycopene, have no beta-ring and thus no vitamin A activity -although they may have antioxidant activity and thus biological activity in other ways-. Animal species differ greatly in their ability to convert retinyl -beta-ionone- containing carotenoids to retinals. Carnivores in general are poor converters of dietary ionone-containing carotenoids. Pure carnivores such as ferrets lack β-carotene 15‚15'-monooxygenase and cannot convert any carotenoids to retinals at all -resulting in carotenes not being a form of vitamin A for this species-; while cats can convert a trace of β-carotene to retinol, although the amount is totally insufficient for meeting their daily retinol needs.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carotene",
+      "wikidata": "Q190156"
+    },
+    {
+      "title": "Carotenoids",
+      "eNumber": "E160",
+      "synonyms": [
+        "E160",
+        "Carotenoids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q191907"
+    },
+    {
+      "title": "Carrageenan",
+      "eNumber": "E407",
+      "synonyms": [
+        "E407",
+        "Carrageenan",
+        "e407 stabilizer"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Carrageenans or carrageenins - karr-ə-gee-nənz, from Irish carraigín, \"little rock\"- are a family of linear sulfated polysaccharides that are extracted from red edible seaweeds. They are widely used in the food industry, for their gelling, thickening, and stabilizing properties. Their main application is in dairy and meat products, due to their strong binding to food proteins. There are three main varieties of carrageenan, which differ in their degree of sulfation. Kappa-carrageenan has one sulfate group per disaccharide, iota-carrageenan has two, and lambda-carrageenan has three. Gelatinous extracts of the Chondrus crispus -Irish moss- seaweed have been used as food additives since approximately the fifteenth century. Carrageenan is a vegetarian and vegan alternative to gelatin in some applications or may be used to replace gelatin in confectionery.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carrageenan",
+      "wikidata": "Q421991"
+    },
+    {
+      "title": "Cassia gum",
+      "eNumber": "E427",
+      "synonyms": [
+        "E427",
+        "Cassia gum"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "The term cassia gum refers to the flour made from the endosperms of the seeds of Senna obtusifolia and Senna tora -also called Cassia obtusifolia or Cassia tora-. It is composed of at least 75% polysaccharide, primarily galactomannan with a mannose:galactose ratio of 5:1, resulting in a high molecular mass of 200‚000-300‚000 Da.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Cassia_gum",
+      "wikidata": "Q3110379"
+    },
+    {
+      "title": "Castor oil",
+      "eNumber": "E1503",
+      "synonyms": [
+        "E1503",
+        "Castor oil"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier"
+      ],
+      "description": "Castor oil is a vegetable oil obtained by pressing the seeds of the castor oil plant -Ricinus communis-. The common name \"castor oil\", from which the plant gets its name, probably comes from its use as a replacement for castoreum, a perfume base made from the dried perineal glands of the beaver -castor in Latin-.Castor oil is a colorless to very pale yellow liquid with a distinct taste and odor. Its boiling point is 313 °C -595 °F- and its density is 961 kg/m3. It is a triglyceride in which approximately 90 percent of fatty acid chains are ricinoleates. Oleate and linoleates are the other significant components. Castor oil and its derivatives are used in the manufacturing of soaps, lubricants, hydraulic and brake fluids, paints, dyes, coatings, inks, cold resistant plastics, waxes and polishes, nylon, pharmaceuticals and perfumes.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Castor_oil",
+      "wikidata": "Q337492"
+    },
+    {
+      "title": "Caustic sulphite caramel",
+      "eNumber": "E150B",
+      "synonyms": [
+        "E150b",
+        "Caustic sulphite caramel",
+        "caramel E150b"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Cellulose",
+      "eNumber": "E460",
+      "synonyms": [
+        "E460",
+        "Cellulose",
+        "cellulose powder to prevent caking",
+        "cellulose powder added to prevent caking"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Cellulose is an organic compound with the formula -C6H10O5-n, a polysaccharide consisting of a linear chain of several hundred to many thousands of β-1→4- linked D-glucose units. Cellulose is an important structural component of the primary cell wall of green plants, many forms of algae and the oomycetes. Some species of bacteria secrete it to form biofilms. Cellulose is the most abundant organic polymer on Earth.  The cellulose content of cotton fiber is 90%, that of wood is 40–50%, and that of dried hemp is approximately 57%.Cellulose is mainly used to produce paperboard and paper. Smaller quantities are converted into a wide variety of derivative products such as cellophane and rayon. Conversion of cellulose from energy crops into biofuels such as cellulosic ethanol is under development as a renewable fuel source. Cellulose for industrial use is mainly obtained from wood pulp and cotton.Some animals, particularly ruminants and termites, can digest cellulose with the help of symbiotic micro-organisms that live in their guts, such as Trichonympha. In human nutrition, cellulose is a non-digestible constituent of insoluble dietary fiber, acting as a hydrophilic bulking agent for feces and potentially aiding in defecation.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Cellulose",
+      "wikidata": "Q80294"
+    },
+    {
+      "title": "Chlorine",
+      "eNumber": "E925",
+      "synonyms": [
+        "E925",
+        "Chlorine",
+        "element 17"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q688"
+    },
+    {
+      "title": "Chlorine dioxide",
+      "eNumber": "E926",
+      "synonyms": [
+        "E926",
+        "Chlorine dioxide"
+      ],
+      "functions": [],
+      "description": "Not to be confused with the chlorite ion.Chlorine dioxide is a chemical compound with the formula ClO2.  This yellowish-green gas crystallizes as bright orange crystals at −59 °C. As one of several oxides of chlorine, it is a potent and useful oxidizing agent used in water treatment and in bleaching.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Chlorine_dioxide",
+      "wikidata": "Q422080"
+    },
+    {
+      "title": "Chlorophyllins",
+      "eNumber": "E140II",
+      "synonyms": [
+        "E140ii",
+        "Chlorophyllins",
+        "CI Natural Green 5",
+        "Sodium Chlorophyllin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Chlorophyll d is a form of chlorophyll, identified by Harold Strain and Winston Manning in 1943. It is present in cyanobacteria which use energy captured from sunlight for photosynthesis. Chlorophyll d absorbs far-red light, at 710 nm wavelength, just outside the optical range. An organism that contains chlorophyll d is adapted to an environment such as moderately deep water, where it can use far red light for photosynthesis, although there is not a lot of visible light.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Chlorophyll_d",
+      "wikidata": "Q82182"
+    },
+    {
+      "title": "Chlorophylls",
+      "eNumber": "E140I",
+      "synonyms": [
+        "E140i",
+        "Chlorophylls",
+        "CI Natural Green 3",
+        "Magnesium Chlorophyll",
+        "chlorophyll"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Chlorophyll d is a form of chlorophyll, identified by Harold Strain and Winston Manning in 1943. It is present in cyanobacteria which use energy captured from sunlight for photosynthesis. Chlorophyll d absorbs far-red light, at 710 nm wavelength, just outside the optical range. An organism that contains chlorophyll d is adapted to an environment such as moderately deep water, where it can use far red light for photosynthesis, although there is not a lot of visible light.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Chlorophyll",
+      "wikidata": "Q82182"
+    },
+    {
+      "title": "Chlorophylls and Chlorophyllins",
+      "eNumber": "E140",
+      "synonyms": [
+        "E140",
+        "Chlorophylls and Chlorophyllins"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Chlorophyll d is a form of chlorophyll, identified by Harold Strain and Winston Manning in 1943. It is present in cyanobacteria which use energy captured from sunlight for photosynthesis. Chlorophyll d absorbs far-red light, at 710 nm wavelength, just outside the optical range. An organism that contains chlorophyll d is adapted to an environment such as moderately deep water, where it can use far red light for photosynthesis, although there is not a lot of visible light.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Chlorophyll_d",
+      "wikidata": "Q26806091"
+    },
+    {
+      "title": "Cholic acid",
+      "eNumber": "E1000",
+      "synonyms": [
+        "E1000",
+        "Cholic acid"
+      ],
+      "functions": [],
+      "description": "Cholic acid, also known as 3α,7α,12α-trihydroxy-5β-cholan-24-oic acid is a primary bile acid that is insoluble in water -soluble in alcohol and acetic acid-,  it is a white crystalline substance.  Salts of cholic acid are called cholates.  Cholic acid, along with chenodeoxycholic acid, is one of the two major bile acids produced by the liver, where it is synthesized from cholesterol.  These two major bile acids are roughly equal in concentration in humans. Derivatives are made from cholyl-CoA, which exchanges its CoA with either glycine, or taurine, yielding glycocholic and taurocholic acid, respectively.Cholic acid downregulates cholesterol-7-α-hydroxylase -rate-limiting step in bile acid synthesis-, and cholesterol does the opposite.  This is why chenodeoxycholic acid, and not cholic acid, can be used to treat gallstones -because decreasing bile acid synthesis would supersaturate the stones even more-.Cholic acid and chenodeoxycholic acid are the most important human bile acids.  Other species may synthesize different bile acids as their predominant primary bile acids.Cholic acid, formulated as Cholbam capsules, is approved by the United States Food and Drug Administration as a treatment for children and adults with bile acid synthesis disorders due to single enzyme defects, and for peroxisomal disorders -such as Zellweger syndrome-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Cholic_acid",
+      "wikidata": "Q287415"
+    },
+    {
+      "title": "Choline salt",
+      "eNumber": "E1001",
+      "synonyms": [
+        "E1001",
+        "Choline salt"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18668392"
+    },
+    {
+      "title": "Citric acid",
+      "eNumber": "E330",
+      "synonyms": [
+        "E330",
+        "Citric acid"
+      ],
+      "functions": [
+        "antioxidant",
+        "sequestrant"
+      ],
+      "description": "Citric acid is a weak organic acid that has the chemical formula C6H8O7. It occurs naturally in citrus fruits. In biochemistry, it is an intermediate in the citric acid cycle, which occurs in the metabolism of all aerobic organisms. More than a million tons of citric acid are manufactured every year. It is used  widely as an acidifier, as a flavoring and chelating agent.A citrate is a derivative of citric acid; that is, the salts, esters, and the polyatomic anion found in solution. An example of the former, a salt is trisodium citrate; an ester is triethyl citrate. When part of a salt, the formula of the citrate ion is written as C6H5O3−7 or C3H5O-COO-3−3.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Citric_acid",
+      "wikidata": "Q159683"
+    },
+    {
+      "title": "Citric acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472C",
+      "synonyms": [
+        "E472c",
+        "Citric acid esters of mono- and diglycerides of fatty acids"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967202"
+    },
+    {
+      "title": "Citrus Red 2",
+      "eNumber": "E121",
+      "synonyms": [
+        "E121",
+        "Citrus Red 2"
+      ],
+      "functions": [],
+      "description": "Citrus Red 2, Citrus Red No. 2, C.I. Solvent Red 80, or C.I. 12156 is an artificial dye. As a food dye, it has been permitted by the US Food and Drug Administration -FDA- since 1956 to color the skin of oranges. Citrus Red 2 is listed by the International Agency for Research on Cancer -IARC- as a group 2B carcinogen, a substance \"possibly carcinogenic to humans\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Citrus_Red_2",
+      "wikidata": "Q2653981"
+    },
+    {
+      "title": "Cochineal",
+      "eNumber": "E120",
+      "synonyms": [
+        "E120",
+        "Cochineal",
+        "carminic acid",
+        "carmines",
+        "Natural Red 4",
+        "Cochineal Red"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Carminic acid -C22H20O13- is a red glucosidal hydroxyanthrapurin that occurs naturally in some scale insects, such as the cochineal, Armenian cochineal, and Polish cochineal. The insects produce the acid as a deterrent to predators. An aluminum salt of carminic acid is the coloring agent in carmine.  Synonyms are C.I. 75470 and C.I. Natural Red 4. The chemical structure of carminic acid consists of a core anthraquinone structure linked to a glucose sugar unit.  Carminic acid was first synthesized in the laboratory by organic chemists in 1991.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carmine",
+      "wikidata": "Q416860"
+    },
+    {
+      "title": "concentrated tocopherol",
+      "eNumber": "E307B",
+      "synonyms": [
+        "E307b",
+        "concentrated tocopherol"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "α-Tocopherol is a type of vitamin E. It has E number \"E307\". Vitamin E exists in eight different forms, four tocopherols and four tocotrienols. All feature a chromane ring, with a hydroxyl group that can donate a hydrogen atom to reduce free radicals and a hydrophobic side chain which allows for penetration into biological membranes. Compared to the others, α-tocopherol is preferentially absorbed and accumulated in humans.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Alpha-Tocopherol",
+      "wikidata": "Q158348"
+    },
+    {
+      "title": "Copper complexes of chlorophyllins",
+      "eNumber": "E141II",
+      "synonyms": [
+        "E141ii",
+        "Copper complexes of chlorophyllins",
+        "Sodium Copper Chlorophyllin",
+        "Potassium Copper Chlorophyllin",
+        "Copper Chlorophyllin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967203"
+    },
+    {
+      "title": "Copper complexes of chlorophylls",
+      "eNumber": "E141I",
+      "synonyms": [
+        "E141i",
+        "Copper complexes of chlorophylls",
+        "CI Natural Green 3",
+        "Copper Chlorophyll"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967203"
+    },
+    {
+      "title": "Copper complexes of chlorophylls and chlorophyllins",
+      "eNumber": "E141",
+      "synonyms": [
+        "E141",
+        "Copper complexes of chlorophylls and chlorophyllins",
+        "Copper complexes of chlorophyll and chlorophyllins"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967203"
+    },
+    {
+      "title": "Copper sulphate",
+      "eNumber": "E519",
+      "synonyms": [
+        "E519",
+        "Copper sulphate",
+        "copperII sulfate"
+      ],
+      "functions": [],
+      "description": "CopperII sulfate, also known as cupric sulfate, or copper sulphate, is the inorganic compound with the chemical formula CuSO4-H2O-x, where x can range from 0 to 5.  The pentahydrate -x = 5- is the most common form.  Older names for this compound include blue vitriol, bluestone, vitriol of copper, and Roman vitriol.The pentahydrate -CuSO4·5H2O-, the most commonly encountered salt, is bright blue. It exothermically dissolves in water to give the aquo complex [Cu-H2O-6]2+, which has octahedral molecular geometry.  The structure of the solid pentahydrate reveals a polymeric structure wherein copper is again octahedral but bound to four water ligands.  The Cu-II--H2O-4 centers are interconnected by sulfate anions to form chains. Anhydrous copper sulfate is a white powder.",
+      "wikipedia": "https://en.wikipedia.org/wiki/CopperII_sulfate",
+      "wikidata": "Q107184"
+    },
+    {
+      "title": "Cross-linked sodium carboxymethylcellulose",
+      "eNumber": "E468",
+      "synonyms": [
+        "E468",
+        "Cross-linked sodium carboxymethylcellulose",
+        "cross-linked cellulose gum",
+        "Crosslinked sodium carboxy methyl cellulose"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967204"
+    },
+    {
+      "title": "Cryptoaxanthin",
+      "eNumber": "E161C",
+      "synonyms": [
+        "E161c",
+        "Cryptoaxanthin",
+        "Cryptoxanthin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Curcumin",
+      "eNumber": "E100",
+      "synonyms": [
+        "E100",
+        "Curcumin",
+        "Turmeric extract",
+        "curcuma extract",
+        "turmeric color"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Curcumin",
+      "wikidata": "Q312266"
+    },
+    {
+      "title": "Curdlan",
+      "eNumber": "E424",
+      "synonyms": [
+        "E424",
+        "Curdlan"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Curdlan is a water-insoluble linear beta-1‚3-glucan, a high-molecular-weight polymer of glucose. Curdlan consists of β--1‚3--linked glucose residues and forms elastic gels upon heating in aqueous suspension. Its was reported to be produced by Alcaligenes faecalis  var. myxogenes in 1966 by Harada et al. . Subsequently, the taxonomy of this non-pathogenic curdlan-producing bacterium has been reclassified as Agrobacterium species.Extracellular and capsular polysaccharides are produced by a variety of pathogenic and soil-dwelling bacteria. Curdlan is a neutral β--1‚3--glucan, perhaps with a few intra- or interchain 1‚6-linkages, produced as an exopolysaccharide by soil bacteria of the family Rhizobiaceae. Four genes required for curdlan production have been identified in Agrobacterium sp. ATCC31749, which produces curdlan in extraordinary amounts, and Agrobacterium tumefaciens. A putative operon contains crdS, encoding β--1‚3--glucan synthase catalytic subunit, flanked by two additional genes. A separate locus contains a putative regulatory gene, crdR. A membrane-bound phosphatidylserine synthase, encoded by pssAG, is also necessary for maximal production of curdlan of high molecular mass. Nitrogen starvation upregulates the curdlan operon and increases the rate of curdlan synthesis.Curdlan has numerous applications as a gelling agent in the food, construction, and pharmaceutical industries and has been approved as a food additive by the U. S. Food and Drug Administration.Recently, curdlan and its derivatives have been found to play a role in both innate and adaptive immunity leading to many new potential curdlan applications in biomedicine.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Curdlan",
+      "wikidata": "Q616242"
+    },
+    {
+      "title": "Cyclamic acid and its Na and Ca salts",
+      "eNumber": "E952",
+      "synonyms": [
+        "E952",
+        "Cyclamic acid and its Na and Ca salts",
+        "Cyclamic acid",
+        "sodium cyclamate",
+        "cyclamates"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Cyclamic acid is a compound with formula  C6H13NO3S. It is included in E number \"E952\". Cyclamic acid is mainly used as catalyst in the production of paints and plastics, and furthermore as a reagent for laboratory usage.The sodium and calcium salts of cyclamic acid are used as artificial sweeteners under the name cyclamate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Cyclamic_acid",
+      "wikidata": "Q2130929"
+    },
+    {
+      "title": "D-Alpha-tocopherol",
+      "eNumber": "E307A",
+      "synonyms": [
+        "E307a",
+        "D-Alpha-tocopherol"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "α-Tocopherol is a type of vitamin E. It has E number \"E307\". Vitamin E exists in eight different forms, four tocopherols and four tocotrienols. All feature a chromane ring, with a hydroxyl group that can donate a hydrogen atom to reduce free radicals and a hydrophobic side chain which allows for penetration into biological membranes. Compared to the others, α-tocopherol is preferentially absorbed and accumulated in humans.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Alpha-Tocopherol",
+      "wikidata": "Q158348"
+    },
+    {
+      "title": "D-Maltitol",
+      "eNumber": "E965I",
+      "synonyms": [
+        "E965i",
+        "D-Maltitol"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Maltitol is a sugar alcohol -a polyol- used as a sugar substitute. It has 75–90% of the sweetness of sucrose -table sugar- and nearly identical properties, except for browning. It is used to replace table sugar because it is half as caloric, does not promote tooth decay, and has a somewhat lesser effect on blood glucose.  In chemical terms, maltitol is known as 4-O-α-glucopyranosyl-D-sorbitol. It is used in commercial products under trade names such as Lesys, Maltisweet and SweetPearl.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Maltitol",
+      "wikidata": "Q423882"
+    },
+    {
+      "title": "D-sorbitol",
+      "eNumber": "E420I",
+      "synonyms": [
+        "E420i",
+        "D-sorbitol",
+        "D-glucitol"
+      ],
+      "functions": [
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Sorbitol --, less commonly known as glucitol --, is a sugar alcohol with a sweet taste which the human body metabolizes slowly. It can be obtained by reduction of glucose, which changes the aldehyde group to a hydroxyl group. Most sorbitol is made from corn syrup, but it is also found in nature, for example in apples, pears, peaches, and prunes. It is converted to fructose by sorbitol-6-phosphate 2-dehydrogenase. Sorbitol is an isomer of mannitol, another sugar alcohol; the two differ only in the orientation of the hydroxyl group on carbon 2. While similar, the two sugar alcohols have very different sources in nature, melting points, and uses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sorbitol",
+      "wikidata": "Q245280"
+    },
+    {
+      "title": "Dehydroacetic acid",
+      "eNumber": "E265",
+      "synonyms": [
+        "E265",
+        "Dehydroacetic acid"
+      ],
+      "functions": [],
+      "description": "Dehydroacetic acid is an organic compound which has several industrial applications. The compound is classified as a pyrone derivative. It presents as an odorless, colorless to white crystalline powder, almost insoluble in water and moderately soluble in most organic solvents.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dehydroacetic_acid",
+      "wikidata": "Q920725"
+    },
+    {
+      "title": "Delta-tocopherol",
+      "eNumber": "E309",
+      "synonyms": [
+        "E309",
+        "Delta-tocopherol",
+        "δ-tocopherol"
+      ],
+      "functions": [],
+      "description": "δ-Tocopherol is one of the chemical compounds that is considered vitamin E.  As a food additive, it has E number E309. See the main article tocopherol for more information.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Delta-Tocopherol",
+      "wikidata": "Q155751"
+    },
+    {
+      "title": "Dextrin",
+      "eNumber": "E1400",
+      "synonyms": [
+        "E1400",
+        "Dextrin"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Dextrins are a group of low-molecular-weight carbohydrates produced by the hydrolysis of starch or glycogen. Dextrins are mixtures of polymers of D-glucose units linked by α--1→4- or α--1→6- glycosidic bonds. Dextrins can be produced from starch using enzymes like amylases, as during digestion in the human body and during malting and mashing, or by applying dry heat under acidic conditions -pyrolysis or roasting-. The latter process is used industrially, and also occurs on the surface of bread during the baking process, contributing to flavor, color and crispness. Dextrins produced by heat are also known as pyrodextrins. The starch hydrolyses during roasting under acidic conditions, and short-chained starch parts partially rebranch with α--1‚6- bonds to the degraded starch molecule. See also Maillard Reaction. Dextrins are white, yellow, or brown powders that are partially or fully water-soluble, yielding optically active solutions of low viscosity. Most of them can be detected with iodine solution, giving a red coloration; one distinguishes erythrodextrin -dextrin that colours red- and achrodextrin -giving no colour-. White and yellow dextrins from starch roasted with little or no acid are called British gum.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dextrin",
+      "wikidata": "Q191978"
+    },
+    {
+      "title": "Di- and triphosphates",
+      "eNumber": "",
+      "synonyms": [
+        "di- and triphosphates"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Dicalcium citrate",
+      "eNumber": "E333II",
+      "synonyms": [
+        "E333ii",
+        "Dicalcium citrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Calcium citrate is the calcium salt of citric acid.  It is commonly used as a food additive -E333-, usually as a preservative, but sometimes for flavor.  In this sense, it is similar to sodium citrate.   Calcium citrate is also found in some dietary calcium supplements -e.g. Citracal-. Calcium makes up 24.1% of calcium citrate -anhydrous- and 21.1% of calcium citrate -tetrahydrate- by mass. The tetrahydrate occurs in nature as the mineral Earlandite.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_citrate",
+      "wikidata": "Q420280"
+    },
+    {
+      "title": "Dicalcium diphosphate",
+      "eNumber": "E450VI",
+      "synonyms": [
+        "E450vi",
+        "Dicalcium diphosphate",
+        "dicalcium pyrophosphate",
+        "e450vi"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_pyrophosphate",
+      "wikidata": "Q4363460"
+    },
+    {
+      "title": "Dicalcium diphosphate",
+      "eNumber": "E540",
+      "synonyms": [
+        "E540",
+        "Dicalcium diphosphate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967208"
+    },
+    {
+      "title": "Dicalcium phosphate",
+      "eNumber": "E341II",
+      "synonyms": [
+        "E341ii",
+        "Dicalcium phosphate",
+        "Dibasic calcium phosphate",
+        "di-calcium phosphate",
+        "dicalcium phosphate",
+        "E 341ii",
+        "E-341ii",
+        "E341 ii"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Calcium phosphate is a family of materials and minerals containing calcium ions -Ca2+- together with inorganic phosphate anions.  Some so-called calcium phosphates contain oxide and hydroxide as well.  They are white solids of nutritious value.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dicalcium_phosphate",
+      "wikidata": "Q414619"
+    },
+    {
+      "title": "Dimagnesium phosphate",
+      "eNumber": "E343II",
+      "synonyms": [
+        "E343ii",
+        "Dimagnesium phosphate",
+        "Magnesiumhydrogenphosphate",
+        "Magnesiumphosphate - dibasic",
+        "Dimagnesium orthophosphate",
+        "magnesium hydrogen phosphate",
+        "dimagnesium phosphate",
+        "E 343ii",
+        "E-343ii",
+        "E343 ii"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dimagnesium_phosphate",
+      "wikidata": "Q14325507"
+    },
+    {
+      "title": "Dimethyl dicarbonate",
+      "eNumber": "E242",
+      "synonyms": [
+        "E242",
+        "Dimethyl dicarbonate",
+        "DMDC",
+        "methoxycarbonyl methyl carbonate",
+        "dicarbonic acid dimethyl ester",
+        "Velcorin"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Dimethyl dicarbonate -DMDC- is an organic compound which is a colorless liquid with a pungent odor at high concentration at room temperature. It is primarily used as a beverage preservative, processing aid, or sterilant -INS No. 242-, and acts by inhibiting the enzymes acetate kinase and L-glutamic acid decarboxylase. It has also been proposed that DMDC inhibits the enzymes alcohol dehydrogenase and glyceraldehyde 3-phosphate dehydrogenase by causing the methoxycarbonylation of their histidine components.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dimethyl_dicarbonate",
+      "wikidata": "Q416985"
+    },
+    {
+      "title": "Dimethyl polysiloxane",
+      "eNumber": "E900A",
+      "synonyms": [
+        "E900a",
+        "Dimethyl polysiloxane",
+        "Polydimethyl siloxane",
+        "Silicone fluid",
+        "Silicone oil",
+        "Polydimethylsiloxane",
+        "dimethicone",
+        "dimethylpolysiloxane"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "Polydimethylsiloxane -PDMS- belongs to a group of polymeric organosilicon compounds that are commonly referred to as silicones. PDMS is the most widely used silicon-based organic polymer, and is particularly known for its unusual rheological -or flow- properties. PDMS is optically clear, and, in general, inert, non-toxic, and non-flammable. It is also called dimethylpolysiloxane or dimethicone and is one of several types of silicone oil -polymerized siloxane-. Its applications range from contact lenses and medical devices to elastomers; it is also present in shampoos -as dimethicone makes hair shiny and slippery-, food -antifoaming agent-, caulking, lubricants and heat-resistant tiles.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polydimethylsiloxane",
+      "wikidata": "Q411955"
+    },
+    {
+      "title": "dimethyl sulfone",
+      "eNumber": "",
+      "synonyms": [
+        "methylsulfonylmethane",
+        "dimethyl sulfone",
+        "methyl sulfone"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Methylsulfonylmethane",
+      "wikidata": "Q423842"
+    },
+    {
+      "title": "Dimethylpolysiloxane and Methylphenylpolysiloxane",
+      "eNumber": "E900",
+      "synonyms": [
+        "E900",
+        "Dimethylpolysiloxane and Methylphenylpolysiloxane"
+      ],
+      "functions": [],
+      "description": "Polydimethylsiloxane -PDMS- belongs to a group of polymeric organosilicon compounds that are commonly referred to as silicones. PDMS is the most widely used silicon-based organic polymer, and is particularly known for its unusual rheological -or flow- properties. PDMS is optically clear, and, in general, inert, non-toxic, and non-flammable. It is also called dimethylpolysiloxane or dimethicone and is one of several types of silicone oil -polymerized siloxane-. Its applications range from contact lenses and medical devices to elastomers; it is also present in shampoos -as dimethicone makes hair shiny and slippery-, food -antifoaming agent-, caulking, lubricants and heat-resistant tiles.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polydimethylsiloxane",
+      "wikidata": "Q411955"
+    },
+    {
+      "title": "Diphosphates",
+      "eNumber": "E450",
+      "synonyms": [
+        "E450",
+        "Diphosphates",
+        "Pyrophosphate",
+        "diphosphate",
+        "E-450",
+        "e 450",
+        "e450 stabilizer"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pyrophosphate",
+      "wikidata": "Q55506489"
+    },
+    {
+      "title": "Diphosphates and sodium carbonates",
+      "eNumber": "",
+      "synonyms": [
+        "diphosphates and sodium carbonates"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "dipotassium dihydrogenpyrophosphate",
+      "eNumber": "E450IV",
+      "synonyms": [
+        "E450iv",
+        "dipotassium dihydrogenpyrophosphate",
+        "E-450iv"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q290828"
+    },
+    {
+      "title": "Dipotassium guanylate",
+      "eNumber": "E628",
+      "synonyms": [
+        "E628",
+        "Dipotassium guanylate",
+        "Potassium guanylate"
+      ],
+      "functions": [],
+      "description": "Dipotassium guanylate is a compound with formula K2-C10H12O4N5PO4-. It is a potassium salt of guanylic acid. As a food additive, it is used as a flavor enhancer and has the E number E628.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dipotassium_guanylate",
+      "wikidata": "Q5280047"
+    },
+    {
+      "title": "Dipotassium inosinate",
+      "eNumber": "E632",
+      "synonyms": [
+        "E632",
+        "Dipotassium inosinate",
+        "Potassium inosinate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18608832"
+    },
+    {
+      "title": "Dipotassium phosphate",
+      "eNumber": "E340II",
+      "synonyms": [
+        "E340ii",
+        "Dipotassium phosphate",
+        "Dipotassium monophosphate",
+        "Secondary potassium phosphate",
+        "Dipotassium orthophosphate",
+        "E 340ii",
+        "E-340ii",
+        "E340 ii"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Potassium phosphate is a generic term for the salts of potassium and phosphate ions including: Monopotassium phosphate -KH2PO4- -Molar mass approx: 136 g/mol- Dipotassium phosphate -K2HPO4- -Molar mass approx: 174 g/mol- Tripotassium phosphate -K3PO4- -Molar mass approx: 212.27 g/mol-As food additives, potassium phosphates have the E number E340.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dipotassium_phosphate",
+      "wikidata": "Q403721"
+    },
+    {
+      "title": "Dipotassium tartrate",
+      "eNumber": "E336II",
+      "synonyms": [
+        "E336ii",
+        "Dipotassium tartrate",
+        "dipotassic tartrate",
+        "Potassium tartrate"
+      ],
+      "functions": [],
+      "description": "Potassium tartrate, dipotassium tartrate or argol has formula K2C4H4O6. It is the potassium salt of tartaric acid.  It is often confused with potassium bitartrate, also known as cream of tartar.  As a food additive, it shares the E number E336 with potassium bitartrate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_tartrate",
+      "wikidata": "Q418064"
+    },
+    {
+      "title": "Disodium 5'-ribonucleotide",
+      "eNumber": "E635",
+      "synonyms": [
+        "E635",
+        "Disodium 5'-ribonucleotide",
+        "Disodium 5'-ribonucleotides"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Disodium_ribonucleotides",
+      "wikidata": "Q18967210"
+    },
+    {
+      "title": "Disodium citrate",
+      "eNumber": "E331II",
+      "synonyms": [
+        "E331ii",
+        "Disodium citrate"
+      ],
+      "functions": [
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Sodium citrate may refer to any of the sodium salts of citrate -though most commonly the third-:  Monosodium citrate Disodium citrate Trisodium citrateThe three forms of the salt are collectively known by the E number E331. Sodium citrates are used as acidity regulators in food and drinks, and also as emulsifiers for oils. They enable cheeses to melt without becoming greasy.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Disodium_citrate",
+      "wikidata": "Q4177124"
+    },
+    {
+      "title": "Disodium diphosphate",
+      "eNumber": "E450I",
+      "synonyms": [
+        "E450i",
+        "Disodium diphosphate",
+        "Sodium Acid Pyrophosphate",
+        "sapp",
+        "disodium dihydrogen pyrophosphate",
+        "disodium pyrophosphate",
+        "sodium acid pyrophosphate",
+        "disodium diphosphate",
+        "disodium dihydrogen diphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Disodium_pyrophosphate",
+      "wikidata": "Q418498"
+    },
+    {
+      "title": "Disodium guanylate",
+      "eNumber": "E627",
+      "synonyms": [
+        "E627",
+        "Disodium guanylate",
+        "Sodium guanylate"
+      ],
+      "functions": [],
+      "description": "Disodium guanylate, also known as sodium 5'-guanylate and disodium 5'-guanylate, is a natural sodium salt of the flavor enhancing nucleotide guanosine monophosphate -GMP-. Disodium guanylate is a food additive with the E number E627. It is commonly used in conjunction with glutamic acid. As it is a fairly expensive additive, it is not used independently of glutamic acid; if disodium guanylate is present in a list of ingredients but MSG does not appear to be, it is likely that glutamic acid is provided as part of another ingredient such as a processed soy protein complex. It is often added to foods in conjunction with disodium inosinate; the combination is known as disodium 5'-ribonucleotides. Disodium guanylate is produced from dried seaweed and is often added to instant noodles, potato chips and other snacks, savory rice, tinned vegetables, cured meats, and packaged soup.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Disodium_guanylate",
+      "wikidata": "Q905776"
+    },
+    {
+      "title": "Disodium inosinate",
+      "eNumber": "E631",
+      "synonyms": [
+        "E631",
+        "Disodium inosinate",
+        "Sodium inosinate"
+      ],
+      "functions": [],
+      "description": "Disodium inosinate -E631- is the disodium salt of inosinic acid with the chemical formula C10H11N4Na2O8P.  It is used as a food additive and often found in instant noodles, potato chips, and a variety of other snacks. Although it can be obtained from bacterial fermentation of sugars, it is often commercially prepared from animal sources.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Disodium_inosinate",
+      "wikidata": "Q905782"
+    },
+    {
+      "title": "Disodium phosphate",
+      "eNumber": "E339II",
+      "synonyms": [
+        "E339ii",
+        "Disodium phosphate",
+        "Disodium monophosphate",
+        "Secondary sodium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "preservative",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium phosphate is a generic term for a variety of salts of sodium -Na+- and phosphate -PO43−-. Phosphate also forms families or condensed anions including di-, tri-, tetra-, and polyphosphates. Most of these salts are known in both anhydrous -water-free- and hydrated forms. The hydrates are more common than the anhydrous forms.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Disodium_phosphate",
+      "wikidata": "Q418448"
+    },
+    {
+      "title": "Disodium tartrate",
+      "eNumber": "E335II",
+      "synonyms": [
+        "E335ii",
+        "Disodium tartrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q17997701"
+    },
+    {
+      "title": "Distarch glycerol",
+      "eNumber": "E1411",
+      "synonyms": [
+        "E1411",
+        "Distarch glycerol"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967214"
+    },
+    {
+      "title": "Distarch phosphate",
+      "eNumber": "E1412",
+      "synonyms": [
+        "E1412",
+        "Distarch phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967218"
+    },
+    {
+      "title": "DL-Alpha-tocopherol",
+      "eNumber": "E307C",
+      "synonyms": [
+        "E307c",
+        "DL-Alpha-tocopherol"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "α-Tocopherol is a type of vitamin E. It has E number \"E307\". Vitamin E exists in eight different forms, four tocopherols and four tocotrienols. All feature a chromane ring, with a hydroxyl group that can donate a hydrogen atom to reduce free radicals and a hydrophobic side chain which allows for penetration into biological membranes. Compared to the others, α-tocopherol is preferentially absorbed and accumulated in humans.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Alpha-Tocopherol",
+      "wikidata": "Q158348"
+    },
+    {
+      "title": "Dodecyl gallate",
+      "eNumber": "E312",
+      "synonyms": [
+        "E312",
+        "Dodecyl gallate"
+      ],
+      "functions": [],
+      "description": "Dodecyl gallate, or lauryl gallate, is the ester of dodecanol and gallic acid.  As a food additive it is used under the E number E312 as an antioxidant and preservative.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Dodecyl_gallate",
+      "wikidata": "Q418209"
+    },
+    {
+      "title": "E101a food additive",
+      "eNumber": "E101A",
+      "synonyms": [
+        "E101a",
+        "E101a food additive"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement. Food sources include eggs, green vegetables, milk and other dairy product, meat, mushrooms, and almonds. Some countries require its addition to grains. As a supplement it is used to prevent and treat riboflavin deficiency and prevent migraines. It may be given by mouth or injection.It is nearly always well tolerated. Normal doses are safe during pregnancy. Riboflavin is in the vitamin B group. It is required by the body for cellular respiration.Riboflavin was discovered in 1920, isolated in 1933, and first made in 1935. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. Riboflavin is available as a generic medication and over the counter. In the United States a month of supplements costs less than 25 USD.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Riboflavin",
+      "wikidata": "Q376061"
+    },
+    {
+      "title": "E105 food additive",
+      "eNumber": "E105",
+      "synonyms": [
+        "E105",
+        "E105 food additive"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E15x food additive",
+      "eNumber": "E15X",
+      "synonyms": [
+        "E15x",
+        "E15x food additive"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E364",
+      "eNumber": "E364",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E364",
+      "eNumber": "E364",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E386",
+      "eNumber": "E386",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E386",
+      "eNumber": "E386",
+      "synonyms": [],
+      "functions": [
+        "antioxidant",
+        "preservative",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081804"
+    },
+    {
+      "title": "E387",
+      "eNumber": "E387",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081802"
+    },
+    {
+      "title": "E389",
+      "eNumber": "E389",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E389",
+      "eNumber": "E389",
+      "synonyms": [],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q17997723"
+    },
+    {
+      "title": "E390",
+      "eNumber": "E390",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E390",
+      "eNumber": "E390",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081806"
+    },
+    {
+      "title": "E411 food additive",
+      "eNumber": "E411",
+      "synonyms": [
+        "E411",
+        "E411 food additive"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E450viii",
+      "eNumber": "E450VIII",
+      "synonyms": [
+        "E450viii"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q290828"
+    },
+    {
+      "title": "E543 food additive",
+      "eNumber": "E543",
+      "synonyms": [
+        "E543",
+        "E543 food additive"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967200"
+    },
+    {
+      "title": "E571",
+      "eNumber": "E571",
+      "synonyms": [
+        "E571"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E638",
+      "eNumber": "E638",
+      "synonyms": [
+        "E638"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E639",
+      "eNumber": "E639",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "E642",
+      "eNumber": "E642",
+      "synonyms": [
+        "E642"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Enzymatically hydrolysed carboxymethylcellulose",
+      "eNumber": "E469",
+      "synonyms": [
+        "E469",
+        "Enzymatically hydrolysed carboxymethylcellulose",
+        "enzymatically hydrolised cellulose gum"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18935689"
+    },
+    {
+      "title": "Enzymatically produced steviol glycosides",
+      "eNumber": "E960C",
+      "synonyms": [
+        "E960c",
+        "Enzymatically produced steviol glycosides"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Enzyme treated starch",
+      "eNumber": "E1405",
+      "synonyms": [
+        "E1405",
+        "Enzyme treated starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967222"
+    },
+    {
+      "title": "Erythorbic acid",
+      "eNumber": "E315",
+      "synonyms": [
+        "E315",
+        "Erythorbic acid",
+        "Isoascorbic acid"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Erythorbic acid -isoascorbic acid, D-araboascorbic acid- is a stereoisomer of ascorbic acid -vitamin C-. It is synthesized by a reaction between methyl 2-keto-D-gluconate and sodium methoxide. It can also be synthesized from sucrose or by strains of Penicillium that have been selected for this feature. It is denoted by E number E315, and is widely used as an antioxidant in processed foods.Clinical trials have been conducted to investigate aspects of the nutritional value of erythorbic acid. One such trial investigated the effects of erythorbic acid on vitamin C metabolism in young women; no effect on vitamin C uptake or clearance from the body was found. A later study found that erythorbic acid is a potent enhancer of nonheme-iron absorption.Since the U.S. Food and Drug Administration banned the use of sulfites as a preservative in foods intended to be eaten fresh -such as salad bar ingredients-, the use of erythorbic acid as a food preservative has increased. It is also used as a preservative in cured meats and frozen vegetables.It was first synthesized in 1933 by the German chemists Kurt Maurer and Bruno Schiedt.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Erythorbic_acid",
+      "wikidata": "Q424531"
+    },
+    {
+      "title": "Erythorbin acid",
+      "eNumber": "E317",
+      "synonyms": [
+        "E317",
+        "Erythorbin acid"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Erythritol",
+      "eNumber": "E968",
+      "synonyms": [
+        "E968",
+        "Erythritol",
+        "Meso-erythritol",
+        "Tetrahydroxybutane",
+        "E-968",
+        "E 968"
+      ],
+      "functions": [
+        "humectant",
+        "sweetener"
+      ],
+      "description": "Erythritol --2R,3S--butane-1‚2,3‚4-tetrol- is a sugar alcohol -or polyol- that has been approved for use as a food additive in the United States and throughout much of the world.  It was discovered in 1848 by Scottish chemist John Stenhouse.  It occurs naturally in some fruit and fermented foods. At the industrial level, it is produced from glucose by fermentation with a yeast, Moniliella pollinis. Erythritol is 60–70% as sweet as sucrose -table sugar- yet it is almost noncaloric, does not affect blood sugar, does not cause tooth decay, and is partially absorbed by the body, excreted in urine and feces. Under U.S. Food and Drug Administration -FDA- labeling requirements, it has a caloric value of 0.2 kilocalories per gram -95% less than sugar and other carbohydrates-, though nutritional labeling varies from country to country.  Some countries, such as Japan and the United States, label it as zero-calorie; the European Union labels it 0 kcal/g.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Erythritol",
+      "wikidata": "Q421873"
+    },
+    {
+      "title": "Erythrosine",
+      "eNumber": "E127",
+      "synonyms": [
+        "E127",
+        "Erythrosine",
+        "FD&C Red 3",
+        "FD & C Red No.3",
+        "Red No. 3",
+        "FD&C Red no3",
+        "FD and C Red 3",
+        "Red 3",
+        "Red 3 lake"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Erythrosine, also known as Red No. 3, is an organoiodine compound, specifically a derivative of fluorone.  It is cherry-pink synthetic, primarily used for food coloring. It is the disodium salt of 2‚4,5‚7-tetraiodofluorescein. Its maximum absorbance is at 530 nm in an aqueous solution, and it is subject to photodegradation.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Erythrosine",
+      "wikidata": "Q420101"
+    },
+    {
+      "title": "Ethanol",
+      "eNumber": "E1510",
+      "synonyms": [
+        "E1510",
+        "Ethanol",
+        "ethyl alcohol",
+        "Methylcarbinol",
+        "Ethyl hydroxide",
+        "Ethyl hydrate"
+      ],
+      "functions": [],
+      "description": "Ethanol, also called alcohol, ethyl alcohol, grain alcohol, and drinking alcohol, is a chemical compound, a simple alcohol with the chemical formula C2H5OH. Its formula can be also written as CH3−CH2−OH or C2H5−OH -an ethyl group linked to a hydroxyl group-, and is often abbreviated as EtOH. Ethanol is a volatile, flammable, colorless liquid with a slight characteristic odor. It is a psychoactive substance and is the principal type of alcohol found in alcoholic drinks. Ethanol is naturally produced by the fermentation of sugars by yeasts or via petrochemical processes, and is most commonly consumed as a popular recreational drug. It also has medical applications as an antiseptic and disinfectant. The compound is widely used as a chemical solvent, either for scientific chemical testing or in synthesis of other organic compounds, and is a vital substance used across many different kinds of manufacturing industries. Ethanol is also used as a clean-burning fuel source.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethanol",
+      "wikidata": "Q153"
+    },
+    {
+      "title": "Ethoxylated Mono- and Di-Glycerides",
+      "eNumber": "E488",
+      "synonyms": [
+        "E488",
+        "Ethoxylated Mono- and Di-Glycerides"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967225"
+    },
+    {
+      "title": "Ethoxyquin",
+      "eNumber": "E324",
+      "synonyms": [
+        "E324",
+        "Ethoxyquin"
+      ],
+      "functions": [],
+      "description": "Ethoxyquin is a quinoline-based antioxidant used as a food preservative in certain countries and originally to control scald on pears after harvest -under commercial names such as \"Stop-Scald\"-. It is used as a preservative in some pet foods to slow the development of rancidity of fats.  Ethoxyquin is also used in some spices to prevent color loss due to oxidation of the natural carotenoid pigments.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethoxyquin",
+      "wikidata": "Q1657816"
+    },
+    {
+      "title": "Ethulose",
+      "eNumber": "E467",
+      "synonyms": [
+        "E467",
+        "Ethulose"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Ethulose is a laxative. It is also known as ethylhydroxyethylcellulose.As a food additive with INS number 467, ethulose is used as an emulsifier.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethulose",
+      "wikidata": "Q5404436"
+    },
+    {
+      "title": "ethyl acetate",
+      "eNumber": "E1504",
+      "synonyms": [
+        "E1504",
+        "ethyl acetate",
+        "ethyl ethanoate"
+      ],
+      "functions": [
+        "carrier"
+      ],
+      "description": "Ethyl acetate -systematically ethyl ethanoate, commonly abbreviated EtOAc or EA- is the organic compound with the formula CH3–COO–CH2–CH3, simplified to C4H8O2. This colorless liquid has a characteristic sweet smell -similar to pear drops- and is used in glues, nail polish removers, decaffeinating tea and coffee. Ethyl acetate is the ester of ethanol and acetic acid; it is manufactured on a large scale for use as a solvent.  The combined annual production in 1985 of Japan, North America, and Europe was about 400‚000 tonnes. In 2004, an estimated 1.3 million tonnes were produced worldwide.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethyl_acetate",
+      "wikidata": "Q407153"
+    },
+    {
+      "title": "Ethyl cellulose",
+      "eNumber": "E462",
+      "synonyms": [
+        "E462",
+        "Ethyl cellulose",
+        "Ethylcellulose"
+      ],
+      "functions": [
+        "carrier",
+        "thickener"
+      ],
+      "description": "Ethyl cellulose is a derivative of cellulose in which some of the hydroxyl groups on the repeating glucose units are converted into ethyl ether groups.  The number of ethyl groups can vary depending on the manufacturer. It is mainly used as a thin-film coating material for coating paper, vitamin and medical pills, and for thickeners in cosmetics and in industrial processes. Food grade ethyl cellulose is one of few non-toxic films and thickeners which are not water soluble. This property allows it to be used to safeguard ingredients from water.Ethyl cellulose is also used as a food additive as an emulsifier -E462-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethyl_cellulose",
+      "wikidata": "Q420113"
+    },
+    {
+      "title": "Ethyl ester of beta-apo-8'-carotenic acid (C 30)",
+      "eNumber": "E160F",
+      "synonyms": [
+        "E160f",
+        "Ethyl ester of beta-apo-8'-carotenic acid (C 30)",
+        "Ethyl ester of beta-apo-8'-carotenic acid",
+        "Food orange 7"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Ethyl gallate",
+      "eNumber": "E313",
+      "synonyms": [
+        "E313",
+        "Ethyl gallate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Ethyl lauroyl arginate",
+      "eNumber": "E243",
+      "synonyms": [
+        "E243",
+        "Ethyl lauroyl arginate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18608852"
+    },
+    {
+      "title": "Ethyl maltol",
+      "eNumber": "E637",
+      "synonyms": [
+        "E637",
+        "Ethyl maltol"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Ethyl methyl cellulose",
+      "eNumber": "E465",
+      "synonyms": [
+        "E465",
+        "Ethyl methyl cellulose",
+        "Ethylmethylcellulose"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Ethyl methyl cellulose is a thickener, vegetable gum, foaming agent and emulsifier.  Its E number is E465.Chemically, it is a derivative of cellulose with ethyl and methyl groups attached by ether linkages.  It can be prepared by treatment of cellulose with dimethyl sulfate and ethyl chloride in the presence of an alkali.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethyl_methyl_cellulose",
+      "wikidata": "Q18579463"
+    },
+    {
+      "title": "Ethyl p-hydroxybenzoate",
+      "eNumber": "E214",
+      "synonyms": [
+        "E214",
+        "Ethyl p-hydroxybenzoate",
+        "Ethylparaben",
+        "ethyl para-hydroxybenzoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Ethylparaben -ethyl para-hydroxybenzoate- is the ethyl ester of p-hydroxybenzoic acid. Its formula is HO-C6H4-CO-O-CH2CH3. It is a member of the class of compounds known as parabens. It is used as an antifungal preservative. As a food additive, it has E number E214. Sodium ethyl para-hydroxybenzoate, the sodium salt of ethylparaben, has the same uses and is given the E number E215.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ethylparaben",
+      "wikidata": "Q229976"
+    },
+    {
+      "title": "Extracts of rosemary",
+      "eNumber": "E392",
+      "synonyms": [
+        "E392",
+        "Extracts of rosemary",
+        "rosemary extract"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Fast Green FCF",
+      "eNumber": "E143",
+      "synonyms": [
+        "E143",
+        "Fast Green FCF",
+        "Food green 3",
+        "C.I. 42053",
+        "Solid Green FCF",
+        "Green 1724",
+        "FD&C Green No. 3",
+        "Green 3"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Fast Green FCF, also called Food green 3, FD&C Green No. 3, Green 1724, Solid Green FCF, and C.I. 42053, is a sea green triarylmethane food dye. Its E number is E143. Fast Green FCF is recommended as a replacement of Light Green SF yellowish in Masson's trichrome, as its color is more brilliant and less likely to fade. It is used as a quantitative stain for histones at alkaline pH after acid extraction of DNA. It is also used as a protein stain in electrophoresis. Its absorption maximum is at 625 nm. Fast Green FCF is poorly absorbed by the intestines. Its use as a food dye is prohibited in European Union and some other countries. It can be used for tinned green peas and other vegetables, jellies, sauces, fish, desserts, and dry bakery mixes at level of up to 100 mg/kg.  In the United States, Fast Green FCF is the least used of the seven main FDA approved dyes.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Fast_Green_FCF",
+      "wikidata": "Q898299"
+    },
+    {
+      "title": "Fatty acid esters of ascorbic acid",
+      "eNumber": "E304",
+      "synonyms": [
+        "E304",
+        "Fatty acid esters of ascorbic acid",
+        "ascorbic acid esters of fatty acid"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Ascorbyl palmitate is an ester formed from ascorbic acid and palmitic acid creating a fat-soluble form of vitamin C.  In addition to its use as a source of vitamin C, it is also used as an antioxidant food additive -E number E304-. It is approved for use as a food additive in the EU, the U.S., Canada, Australia, and New Zealand.Ascorbyl palmitate is known to be broken down -through the digestive process- into ascorbic acid and palmitic acid -a saturated fatty acid- before being absorbed into the bloodstream. Ascorbyl palmitate is also marketed as \"vitamin C ester\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ascorbyl_palmitate",
+      "wikidata": "Q43303953"
+    },
+    {
+      "title": "Fatty acid methyl ester",
+      "eNumber": "E911",
+      "synonyms": [
+        "E911",
+        "Fatty acid methyl ester"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18944655"
+    },
+    {
+      "title": "Fatty acids",
+      "eNumber": "E570",
+      "synonyms": [
+        "E570",
+        "Fatty acids",
+        "Linear fatty acids",
+        "caprylic acid (C8)",
+        "caprylic acid",
+        "capric acid (C10)",
+        "capric acid",
+        "lauric acid (C12)",
+        "lauric acid",
+        "myristic acid (C14)",
+        "myristic acid",
+        "palmitic acid (C16)",
+        "palmitic acid",
+        "stearic acid (C18)",
+        "stearic acid",
+        "fatty acid"
+      ],
+      "functions": [],
+      "description": "In chemistry, particularly in biochemistry, a fatty acid is a carboxylic acid with a long aliphatic chain, which is either saturated or unsaturated. Most naturally occurring fatty acids have an unbranched chain of an even number of carbon atoms, from 4 to 28. Fatty acids are usually not found per se in organisms, but instead as three main classes of esters: triglycerides, phospholipids, and cholesterol esters. In any of these forms, fatty acids are both important dietary sources of fuel for animals and they are important structural components for cells.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Fatty_acid",
+      "wikidata": "Q61476"
+    },
+    {
+      "title": "ferric ammonium citrate",
+      "eNumber": "E381",
+      "synonyms": [
+        "E381",
+        "ferric ammonium citrate",
+        "ammonium ferric citrate"
+      ],
+      "functions": [],
+      "description": "Ammonium ferric citrate has the formula -NH4-5[Fe-C6H4O7-2]. A distinguishing feature of this compound is that it is very soluble in water, in contrast to ferric citrate which is not very soluble. In its crystal structure each citric acid moiety has lost four protons, and the deprotonated hydroxyl groups act as ligands together with four carboxylate groups; two carboxylate groups are not coordinated to the ferric ion.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ammonium_ferric_citrate",
+      "wikidata": "Q473522"
+    },
+    {
+      "title": "Ferrous carbonate",
+      "eNumber": "E505",
+      "synonyms": [
+        "E505",
+        "Ferrous carbonate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967227"
+    },
+    {
+      "title": "ferrous hexacyanomanganate",
+      "eNumber": "E537",
+      "synonyms": [
+        "E537",
+        "ferrous hexacyanomanganate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18602070"
+    },
+    {
+      "title": "Ferrous lactate",
+      "eNumber": "E585",
+      "synonyms": [
+        "E585",
+        "Ferrous lactate",
+        "Iron-II lactate"
+      ],
+      "functions": [],
+      "description": "Ferrous lactate, or ironII lactate, is a chemical compound consisting of one atom of iron -Fe2+- and two lactate anions.  It has the chemical formula Fe-C3H5O3-2.",
+      "wikipedia": "https://en.wikipedia.org/wiki/IronII_lactate",
+      "wikidata": "Q836793"
+    },
+    {
+      "title": "flavin mononucleotide",
+      "eNumber": "E106",
+      "synonyms": [
+        "E106",
+        "flavin mononucleotide"
+      ],
+      "functions": [],
+      "description": "Flavin mononucleotide -FMN-, or riboflavin-5′-phosphate, is a biomolecule produced from riboflavin -vitamin B2- by the enzyme riboflavin kinase and functions as prosthetic group of various oxidoreductases including NADH dehydrogenase as well as cofactor in biological blue-light photo receptors. During the catalytic cycle, a reversible interconversion of the oxidized -FMN-, semiquinone -FMNH•- and reduced -FMNH2- forms occurs in the various oxidoreductases. FMN is a stronger oxidizing agent than NAD and is particularly useful because it can take part in both one- and two-electron transfers. In its role as blue-light photo receptor, -oxidized- FMN stands out from the 'conventional' photo receptors as the signaling state and not an E/Z isomerization. It is the principal form in which riboflavin is found in cells and tissues. It requires more energy to produce, but is more soluble than riboflavin.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Flavin_mononucleotide",
+      "wikidata": "Q376061"
+    },
+    {
+      "title": "Formaldehyde",
+      "eNumber": "E240",
+      "synonyms": [
+        "E240",
+        "Formaldehyde",
+        "methanal"
+      ],
+      "functions": [],
+      "description": "Formaldehyde -systematic name methanal- is a naturally occurring organic compound with the formula CH2O -H-CHO-. It is the simplest of the aldehydes -R-CHO-. The common name of this substance comes from its similarity and relation to formic acid. Formaldehyde is an important precursor to many other materials and chemical compounds. In 1996, the installed capacity for the production of formaldehyde was estimated to be 8.7 million tons per year.  It is mainly used in the production of industrial resins, e.g., for particle board and coatings. In view of its widespread use, toxicity, and volatility, formaldehyde poses a significant danger to human health. In 2011, the US National Toxicology Program described formaldehyde as \"known to be a human carcinogen\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Formaldehyde",
+      "wikidata": "Q161210"
+    },
+    {
+      "title": "Formic acid",
+      "eNumber": "E236",
+      "synonyms": [
+        "E236",
+        "Formic acid",
+        "methanoic acid"
+      ],
+      "functions": [],
+      "description": "Formic acid, systematically named methanoic acid, is the simplest carboxylic acid. The chemical formula is HCOOH or HCO2H. It is an important intermediate in chemical synthesis and occurs naturally, most notably in some ants. The word \"formic\" comes from the Latin word for ant, formica, referring to its early isolation by the distillation of ant bodies. Esters, salts, and the anion derived from formic acid are called formates. Industrially formic acid is produced from methanol.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Formic_acid",
+      "wikidata": "Q161233"
+    },
+    {
+      "title": "Fumaric acid",
+      "eNumber": "E297",
+      "synonyms": [
+        "E297",
+        "Fumaric acid",
+        "trans-Butenedioic acid"
+      ],
+      "functions": [],
+      "description": "Fumaric acid or trans-butenedioic acid is the chemical compound with the formula HO2CCH=CHCO2H. It is produced in eukaryotic organisms from succinate in complex 2 of the electron transport chain via the enzyme succinate dehydrogenase.  It is one of two isomeric unsaturated dicarboxylic acids, the other being maleic acid.  In fumaric acid the carboxylic acid groups are trans -E- and in maleic acid they are cis -Z-.  Fumaric acid has a fruit-like taste. The salts and esters are known as fumarates.  Fumarate can also refer to the C4H2O2−4 ion -in solution-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Fumaric_acid",
+      "wikidata": "Q139857"
+    },
+    {
+      "title": "Gamma-Cyclodextrine",
+      "eNumber": "E458",
+      "synonyms": [
+        "E458",
+        "Gamma-Cyclodextrine"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Gamme-tocopherol",
+      "eNumber": "E308",
+      "synonyms": [
+        "E308",
+        "Gamme-tocopherol",
+        "gamma-Tocopherol"
+      ],
+      "functions": [],
+      "description": "γ-Tocopherol is one of the chemical compounds that is considered vitamin E.  As a food additive, it has E number E308. See the main article tocopherol for more information.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Gamma-Tocopherol",
+      "wikidata": "Q155753"
+    },
+    {
+      "title": "Gardenia Blue",
+      "eNumber": "E165",
+      "synonyms": [
+        "E165",
+        "Gardenia Blue"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Gärungskohlensäure",
+      "eNumber": "",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Gelatine",
+      "eNumber": "E428",
+      "synonyms": [
+        "E428",
+        "Gelatine",
+        "gelatin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q179254"
+    },
+    {
+      "title": "Gellan gum",
+      "eNumber": "E418",
+      "synonyms": [
+        "E418",
+        "Gellan gum",
+        "gellan",
+        "E-418",
+        "E 418",
+        "INS418",
+        "INS-418",
+        "INS 418"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Gellan gum is a water-soluble anionic polysaccharide produced by the bacterium Sphingomonas elodea -formerly Pseudomonas elodea based on the taxonomic classification at the time of its discovery-.  Its taxonomic classification has been subsequently changed to Sphingomonas elodea based on current classification system. The gellan-producing bacterium was discovered and isolated by the former Kelco Division of Merck & Company, Inc. in 1978 from the lily plant tissue from a natural pond in Pennsylvania, USA. It was initially identified as a substitute gelling agent at significantly lower use level to replace agar in solid culture media for the growth of various microorganisms  Its initial commercial product with the trademark as \"GELRITE\" gellan gum, was subsequently identified as a suitable agar substitute as gelling agent in various clinical bacteriological media.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Gellan_gum",
+      "wikidata": "Q416694"
+    },
+    {
+      "title": "Gluconic acid",
+      "eNumber": "E574",
+      "synonyms": [
+        "E574",
+        "Gluconic acid",
+        "D-gluconic acid"
+      ],
+      "functions": [],
+      "description": "Gluconic acid is an organic compound with molecular formula C6H12O7 and condensed structural formula HOCH2-CHOH-4COOH.  It is one of the 16 stereoisomers of 2‚3,4‚5,6-pentahydroxyhexanoic acid. In aqueous solution at neutral pH, gluconic acid forms the gluconate ion. The salts of gluconic acid are known as \"gluconates\".  Gluconic acid, gluconate salts, and gluconate esters occur widely in nature because such species arise from the oxidation of glucose.  Some drugs are injected in the form of gluconates.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Gluconic_acid",
+      "wikidata": "Q407569"
+    },
+    {
+      "title": "Glucono-delta-lactone",
+      "eNumber": "E575",
+      "synonyms": [
+        "E575",
+        "Glucono-delta-lactone",
+        "Gluconolactone",
+        "GDL",
+        "D-Gluconic acid delta-lactone"
+      ],
+      "functions": [
+        "sequestrant"
+      ],
+      "description": "Glucono delta-lactone -GDL-, also known as gluconolactone, is a food additive with the E number E575 used as a sequestrant, an acidifier, or a curing, pickling, or leavening agent. It is a lactone of D-gluconic acid. Pure GDL is a white odorless crystalline powder. GDL has been marketed for use in feta cheese. GDL is neutral, but hydrolyses in water to gluconic acid which is acidic, adding a tangy taste to foods, though it has roughly a third of the sourness of citric acid. It is metabolized to 6-phospho-D-gluconate; one gram of GDL yields roughly the same amount of metabolic energy as one gram of sugar. Upon addition to water, GDL is partially hydrolysed to gluconic acid, with the balance between the lactone form and the acid form established as a chemical equilibrium. The rate of hydrolysis of GDL is increased by heat and high pH.The yeast Saccharomyces bulderi can be used to ferment gluconolactone to ethanol and carbon dioxide. The pH value greatly affects culture growth. Gluconolactone at 1 or 2% in a mineral media solution causes the pH to drop below 3.It is also a complete inhibitor of the enzyme amygdalin beta-glucosidase at concentrations of 1 mM.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Glucono_delta-lactone",
+      "wikidata": "Q114174"
+    },
+    {
+      "title": "Glucose oxidase",
+      "eNumber": "E1102",
+      "synonyms": [
+        "E1102",
+        "Glucose oxidase"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "The glucose oxidase enzyme -GOx- also known as notatin -EC number 1.1.3.4- is an oxido-reductase that catalyses the oxidation of glucose to hydrogen peroxide and D-glucono-δ-lactone. This enzyme is produced by certain species of fungi and insects and displays antibacterial activity when oxygen and glucose are present.  Glucose oxidase is widely used for the determination of free glucose in body fluids -diagnostics-, in vegetal raw material, and in the food industry. It also has many applications in biotechnologies, typically enzyme assays for biochemistry including biosensors in nanotechnologies. It was first isolated by Detlev Müller in 1928 from Aspergillus niger.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Glucose_oxidase",
+      "wikidata": "Q419321"
+    },
+    {
+      "title": "Glucosylated steviol glycosides",
+      "eNumber": "E960D",
+      "synonyms": [
+        "E960d",
+        "Glucosylated steviol glycosides"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Glutamic acid",
+      "eNumber": "E620",
+      "synonyms": [
+        "E620",
+        "Glutamic acid",
+        "L-Glutamic acid"
+      ],
+      "functions": [],
+      "description": "Glutamic acid -symbol Glu or E- is an α-amino acid that is used by almost all living beings in the biosynthesis of proteins.  It is non-essential in humans, meaning the body can synthesize it. It is also an excitatory neurotransmitter, in fact the most abundant one, in the vertebrate nervous system. It serves as the precursor for the synthesis of the inhibitory gamma-aminobutyric acid -GABA- in GABA-ergic neurons. It has a formula C5H9O4N. Its molecular structure could be idealized as HOOC-CH-NH2---CH2-2-COOH, with two carboxyl groups -COOH and one amino group -NH2.  However, in the solid state and mildly acid water solutions, the molecule assumes an electrically neutral zwitterion structure −OOC-CH-NH+3---CH2-2-COOH. It is encoded by the codons GAA or GAG. The acid can lose one proton from its second carboxyl group to form the conjugate base, the singly-negative anion glutamate −OOC-CH-NH+3---CH2-2-COO−.  This form of the compound is prevalent in neutral solutions. The glutamate neurotransmitter plays the principal role in neural activation.  This anion is also responsible for the savory flavor -umami- of certain foods, and used in glutamate flavorings such as MSG.  In highly alkaline solutions the doubly negative anion −OOC-CH-NH2---CH2-2-COO− prevails. The radical corresponding to glutamate is called glutamyl.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Glutamic_acid",
+      "wikidata": "Q181136"
+    },
+    {
+      "title": "Glycerol",
+      "eNumber": "E422",
+      "synonyms": [
+        "E422",
+        "Glycerol",
+        "Glycerin",
+        "Glycerine",
+        "vegetable glycerine"
+      ],
+      "functions": [
+        "humectant",
+        "thickener"
+      ],
+      "description": "Glycerol -; also called glycerine or glycerin; see spelling differences- is a simple polyol compound. It is a colorless, odorless, viscous liquid that is sweet-tasting and non-toxic. The glycerol backbone is found in all lipids known as triglycerides. It is widely used in the food industry as a sweetener and humectant and in pharmaceutical formulations. Glycerol has three hydroxyl groups that are responsible for its solubility in water and its hygroscopic nature.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Glycerol",
+      "wikidata": "Q132501"
+    },
+    {
+      "title": "Glycerol esters of wood rosin",
+      "eNumber": "E445",
+      "synonyms": [
+        "E445",
+        "Glycerol esters of wood rosin",
+        "Glycerol ester of wood rosin",
+        "glyceryl abietate",
+        "ester gum"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Glycerol ester of wood rosin, also known as glyceryl abietate or ester gum, is an oil-soluble food additive -E number E445-. The food-grade material is used in foods, beverages, and cosmetics to keep oils in suspension in water, and its name may be shortened in the ingredient list as glycerol ester of rosin. It is also used as an ingredient in the production of chewing-gum and ice cream. Similar, less pure materials -glycerol ester of gum rosin- are used as a component of certain low-cost adhesives.To make the glycerol ester of wood rosin, refined wood rosin is reacted with glycerin to produce the glycerol ester.  Glycerol ester of wood rosin is an alternative to brominated vegetable oil in citrus oil-flavored soft drinks. In some cases, both ingredients are used together.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Glycerol_ester_of_wood_rosin",
+      "wikidata": "Q836765"
+    },
+    {
+      "title": "Glyceryl diacetate",
+      "eNumber": "E1517",
+      "synonyms": [
+        "E1517",
+        "Glyceryl diacetate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q904648"
+    },
+    {
+      "title": "Glyceryl triacetate",
+      "eNumber": "E1518",
+      "synonyms": [
+        "E1518",
+        "Glyceryl triacetate",
+        "Triacetin",
+        "glycerin triacetate",
+        "1‚2‚3-triacetoxypropane"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant"
+      ],
+      "description": "The triglyceride 1‚2,3-triacetoxypropane is more generally known as triacetin and glycerin triacetate. It is the triester of glycerol and acetylating agents, such as acetic acid and acetic anhydride. It is a colorless, viscous and odorless liquid with a high boiling point. Triacetin was first prepared in 1854 by the French chemist Marcellin Berthelot.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Triacetin",
+      "wikidata": "Q83253"
+    },
+    {
+      "title": "Glycine",
+      "eNumber": "E640I",
+      "synonyms": [
+        "E640i",
+        "Glycine"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967228"
+    },
+    {
+      "title": "Glycine and its sodium salt",
+      "eNumber": "E640",
+      "synonyms": [
+        "E640",
+        "Glycine and its sodium salt"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967228"
+    },
+    {
+      "title": "Glycolipids",
+      "eNumber": "E246",
+      "synonyms": [
+        "E246",
+        "Glycolipids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Glycyrrhizin",
+      "eNumber": "E958",
+      "synonyms": [
+        "E958",
+        "Glycyrrhizin"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Glycyrrhizin -or glycyrrhizic acid  or glycyrrhizinic acid- is the chief sweet-tasting constituent of Glycyrrhiza glabra -liquorice- root. Structurally, it is a saponin used as an emulsifier and gel-forming agent in foodstuffs and cosmetics. Its aglycone is enoxolone assessed as a prodrug used in Japan to reduce the risk of liver cancer in people with chronic hepatitis C.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Glycyrrhizin",
+      "wikidata": "Q418705"
+    },
+    {
+      "title": "Gold",
+      "eNumber": "E175",
+      "synonyms": [
+        "E175",
+        "Gold",
+        "Pigment Metal 3",
+        "element 79"
+      ],
+      "functions": [],
+      "description": "Gold is a chemical element with symbol Au -from Latin: aurum- and atomic number 79, making it one of the higher atomic number elements that occur naturally. In its purest form, it is a bright, slightly reddish yellow, dense, soft, malleable, and ductile metal. Chemically, gold is a transition metal and a group 11 element. It is one of the least reactive chemical elements and is solid under standard conditions. Gold often occurs in free elemental -native- form, as nuggets or grains, in rocks, in veins, and in alluvial deposits. It occurs in a solid solution series with the native element silver -as electrum- and also naturally alloyed with copper and palladium. Less commonly, it occurs in minerals as gold compounds, often with tellurium -gold tellurides-. Gold is resistant to most acids, though it does dissolve in aqua regia, a mixture of nitric acid and hydrochloric acid, which forms a soluble tetrachloroaurate anion. Gold is insoluble in nitric acid, which dissolves silver and base metals, a property that has long been used to refine gold and to confirm the presence of gold in metallic objects, giving rise to the term acid test. Gold also dissolves in alkaline solutions of cyanide, which are used in mining and electroplating. Gold dissolves in mercury, forming amalgam alloys, but this is not a chemical reaction. A relatively rare element, gold is a precious metal that has been used for coinage, jewelry, and other arts throughout recorded history. In the past, a gold standard was often implemented as a monetary policy, but gold coins ceased to be minted as a circulating currency in the 1930s, and the world gold standard was abandoned for a fiat currency system after 1971. A total of 186‚700 tonnes of gold exists above ground, as of 2015. The world consumption of new gold produced is about 50% in jewelry, 40% in investments, and 10% in industry. Gold's high malleability, ductility, resistance to corrosion and most other chemical reactions, and conductivity of electricity have led to its continued use in corrosion resistant electrical connectors in all types of computerized devices -its chief industrial use-. Gold is also used in infrared shielding, colored-glass production, gold leafing, and tooth restoration. Certain gold salts are still used as anti-inflammatories in medicine. As of 2016, the world's largest gold producer by far was China with 450 tonnes per year.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Gold",
+      "wikidata": "Q897"
+    },
+    {
+      "title": "Green s",
+      "eNumber": "E142",
+      "synonyms": [
+        "E142",
+        "Green s",
+        "CI Food Green 4"
+      ],
+      "functions": [],
+      "description": "Green S is a green synthetic coal tar triarylmethane dye with the molecular formula C27H25N2O7S2Na. As a food dye, it has E number E142. It can be used in mint sauce, desserts, gravy granules, sweets, ice creams, and tinned peas.  Green S is prohibited as a food additive in Canada, United States, Japan, and Norway. It is approved for use as a food additive in the EU and Australia and New Zealand.Green S is a vital dye, meaning it can be used to stain living cells. It is used in ophthalmology, along with fluorescein and rose bengal, to diagnose various disorders of the eye's surface, dry eyes for example.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Green_S",
+      "wikidata": "Q420143"
+    },
+    {
+      "title": "Guaiacum",
+      "eNumber": "E314",
+      "synonyms": [
+        "E314",
+        "Guaiacum"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "",
+      "wikipedia": "Gum_guaicum",
+      "wikidata": ""
+    },
+    {
+      "title": "Guanylic acid",
+      "eNumber": "E626",
+      "synonyms": [
+        "E626",
+        "Guanylic acid",
+        "guanosine monophosphate"
+      ],
+      "functions": [],
+      "description": "Guanosine monophosphate -GMP-, also known as 5'-guanidylic acid or guanylic acid -conjugate base guanylate-, is a nucleotide that is used as a monomer in RNA. It is an ester of phosphoric acid with the nucleoside guanosine. GMP consists of the phosphate group, the pentose sugar ribose, and the nucleobase guanine; hence it is a ribonucleoside monophosphate. Guanosine monophosphate is commercially produced by microbial fermentation.Guanosine monophosphate in the form of its salts, such as disodium guanylate -E627-, dipotassium guanylate -E628- and calcium guanylate -E629-, are food additives used as flavor enhancers to provide the umami taste. It is often used in synergy with disodium inosinate; the combination is known as disodium 5'-ribonucleotides. Disodium guanylate is often found in instant noodles, potato chips and snacks, savoury rice, tinned vegetables, cured meats, and packet soup. As it is a fairly expensive additive, it is usually not used independently of glutamic acid or monosodium glutamate -MSG-, which also contribute umami.  If inosinate and guanylate salts are present in a list of ingredients but MSG does not appear to be, the glutamic acid is likely provided as part of another ingredient, such as a processed soy protein complex -hydrolyzed soy protein-, autolyzed yeast, or soy sauce. As inhibitor of guanosine monophosphate synthesis in experimental models, the glutamine analogue DON can be used.As an acyl substituent, it takes the form of the prefix guanylyl-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Guanosine_monophosphate",
+      "wikidata": "Q422473"
+    },
+    {
+      "title": "Guar gum",
+      "eNumber": "E412",
+      "synonyms": [
+        "E412",
+        "Guar gum",
+        "Gum cyamopsis",
+        "guar flour"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Guar gum, also called guaran, is a galactomannan polysaccharide extracted from guar beans that has thickening and stabilizing properties useful in the food, feed and industrial applications. The guar seeds are mechanically dehusked, hydrated, milled and screened according to application. It is typically produced as a free-flowing, off-white powder.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Guar_gum",
+      "wikidata": "Q422071"
+    },
+    {
+      "title": "Gum ghatti",
+      "eNumber": "E419",
+      "synonyms": [
+        "E419",
+        "Gum ghatti"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967232"
+    },
+    {
+      "title": "Gum Guaicum",
+      "eNumber": "E241",
+      "synonyms": [
+        "E241",
+        "Gum Guaicum"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "Gum_guaicum",
+      "wikidata": ""
+    },
+    {
+      "title": "Helium",
+      "eNumber": "E939",
+      "synonyms": [
+        "E939",
+        "Helium",
+        "element 2"
+      ],
+      "functions": [],
+      "description": "Helium -from Greek: ἥλιος, translit. Helios, lit. 'Sun'- is a chemical element with symbol He and atomic number 2. It is a colorless, odorless, tasteless, non-toxic, inert, monatomic gas, the first in the noble gas group in the periodic table. Its boiling point is the lowest among all the elements. After hydrogen, helium is the second lightest and second most abundant element in the observable universe, being present at about 24% of the total elemental mass, which is more than 12 times the mass of all the heavier elements combined. Its abundance is similar to this figure in the Sun and in Jupiter. This is due to the very high nuclear binding energy -per nucleon- of helium-4 with respect to the next three elements after helium. This helium-4 binding energy also accounts for why it is a product of both nuclear fusion and radioactive decay. Most helium in the universe is helium-4, the vast majority of which was formed during the Big Bang. Large amounts of new helium are being created by nuclear fusion of hydrogen in stars. Helium is named for the Greek Titan of the Sun, Helios. It was first detected as an unknown yellow spectral line signature in sunlight during a solar eclipse in 1868 by Georges Rayet, Captain C. T. Haig, Norman R. Pogson, and Lieutenant John Herschel, and was subsequently confirmed by French astronomer Jules Janssen. Janssen is often jointly credited with detecting the element along with Norman Lockyer. Janssen recorded the helium spectral line during the solar eclipse of 1868 while Lockyer observed it from Britain. Lockyer was the first to propose that the line was due to a new element, which he named. The formal discovery of the element was made in 1895 by two Swedish chemists, Per Teodor Cleve and Nils Abraham Langlet, who found helium emanating from the uranium ore cleveite. In 1903, large reserves of helium were found in natural gas fields in parts of the United States, which is by far the largest supplier of the gas today. Liquid helium is used in cryogenics -its largest single use, absorbing about a quarter of production-, particularly in the cooling of superconducting magnets, with the main commercial application being in MRI scanners. Helium's other industrial uses—as a pressurizing and purge gas, as a protective atmosphere for arc welding and in processes such as growing crystals to make silicon wafers—account for half of the gas produced. A well-known but minor use is as a lifting gas in balloons and airships. As with any gas whose density differs from that of air, inhaling a small volume of helium temporarily changes the timbre and quality of the human voice. In scientific research, the behavior of the two fluid phases of helium-4 -helium I and helium II- is important to researchers studying quantum mechanics -in particular the property of superfluidity- and to those looking at the phenomena, such as superconductivity, produced in matter near absolute zero. On Earth it is relatively rare—5.2 ppm by volume in the atmosphere. Most terrestrial helium present today is created by the natural radioactive decay of heavy radioactive elements -thorium and uranium, although there are other examples-, as the alpha particles emitted by such decays consist of helium-4 nuclei. This radiogenic helium is trapped with natural gas in concentrations as great as 7% by volume, from which it is extracted commercially by a low-temperature separation process called fractional distillation. Previously, terrestrial helium—a non-renewable resource, because once released into the atmosphere it readily escapes into space—was thought to be in increasingly short supply. However, recent studies suggest that helium produced deep in the earth by radioactive decay can collect in natural gas reserves in larger than expected quantities, in some cases having been released by volcanic activity.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Helium",
+      "wikidata": "Q560"
+    },
+    {
+      "title": "hemimorphite",
+      "eNumber": "E557",
+      "synonyms": [
+        "E557",
+        "hemimorphite",
+        "calamine"
+      ],
+      "functions": [],
+      "description": "Hemimorphite, is Zn4-Si2O7--OH-2·H2O, a component of calamine. It is a sorosilicate mineral which has been historically mined from the upper parts of zinc and lead ores, chiefly associated with smithsonite, ZnCO3. They were assumed to be the same mineral and both were classed under the same name of calamine. In the second half of the 18th century it was discovered that these two different minerals were both present in calamine. They closely resemble each other. The silicate was the rarer of the two, and was named hemimorphite,  because of the hemimorph development of its crystals. This unusual form, which is typical of only a few minerals, means that the crystals are terminated by dissimilar faces. Hemimorphite most commonly forms crystalline crusts and layers, also massive, granular, rounded and reniform aggregates, concentrically striated, or finely needle-shaped, fibrous or stalactitic, and rarely fan-shaped clusters of crystals. Some specimens show strong green fluorescence in shortwave ultraviolet light -253.7 nm- and weak light pink fluorescence in longwave UV.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Hemimorphite",
+      "wikidata": "Q408008"
+    },
+    {
+      "title": "Heptylparaben",
+      "eNumber": "E209",
+      "synonyms": [
+        "E209",
+        "Heptylparaben"
+      ],
+      "functions": [],
+      "description": "Heptylparaben -heptyl p-hydroxybenzoate- is a compound with formula C7H15-C6H4OHCOO-. It is a paraben which is the heptyl ester of p-hydroxybenzoic acid. Heptylparaben has also been found to be produced in some microorganisms including Microbulbifer.As a food additive it has E number E209, and is used as a preservative.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Heptylparaben",
+      "wikidata": "Q5732121"
+    },
+    {
+      "title": "Hexamethylene tetramine",
+      "eNumber": "E239",
+      "synonyms": [
+        "E239",
+        "Hexamethylene tetramine",
+        "Hexamine",
+        "hexamethylenetetramine"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Hexamethylenetetramine or methenamine, also known as urotropin, is a heterocyclic organic compound with the formula -CH2-6N4.  This white crystalline compound is highly soluble in water and polar organic solvents.  It has a cage-like structure similar to adamantane.  It is useful in the synthesis of other chemical compounds, e.g., plastics, pharmaceuticals, rubber additives.  It sublimes in vacuum at 280 °C.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Hexamethylenetetramine",
+      "wikidata": "Q71969"
+    },
+    {
+      "title": "Hydrochloric acid",
+      "eNumber": "E507",
+      "synonyms": [
+        "E507",
+        "Hydrochloric acid",
+        "Hydrogen chloride"
+      ],
+      "functions": [],
+      "description": "Hydrochloric acid is a colorless inorganic chemical system with the formula H2O:HCl. Hydrochloric acid has a distinctive pungent smell. It is mainly produced as a precursor to vinyl chloride for PVC. It is classified as strongly acidic and can attack the skin over a wide composition range, since the hydrogen chloride practically dissociates completely in solution. Hydrochloric acid is the simplest chlorine-based acid system containing water. It consists of hydrogen chloride and water, and a variety of other chemical species, including hydronium and chloride ions. It is an important chemical reagent and industrial chemical, used primarily in the production of polyvinyl chloride for plastic. In households, diluted hydrochloric acid is often used as a descaling agent. In the food industry, hydrochloric acid used as a food additive and in the production of gelatin. Hydrochloric acid is also used in leather processing. Hydrochloric acid was discovered by the alchemist Jabir ibn Hayyan around the year 800 AD. Hydrochloric acid was historically called acidum salis, muriatic acid, and spirits of salt because it was produced from rock salt and \"green vitriol\" -IronII sulfate- -by Basilius Valentinus in the 15th century- and later from the chemically similar common salt and sulfuric acid -by Johann Rudolph Glauber in the 17th century-. Free hydrochloric acid was first formally described in the 16th century by Libavius. Later, it was used by chemists such as Glauber, Priestley, and Davy in their scientific research. Unless pressurized or cooled, hydrochloric acid will turn into a gas if there is around 60% or less of water. Hydrochloric acid is also known as hydronium chloride.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Hydrochloric_acid",
+      "wikidata": "Q2409"
+    },
+    {
+      "title": "Hydrogen",
+      "eNumber": "E949",
+      "synonyms": [
+        "E949",
+        "Hydrogen"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q556"
+    },
+    {
+      "title": "Hydrogenated poly-1-decene",
+      "eNumber": "E907",
+      "synonyms": [
+        "E907",
+        "Hydrogenated poly-1-decene",
+        "Hydrogenated polydec-1-ene",
+        "Crystalline wax"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967207"
+    },
+    {
+      "title": "Hydroxy propyl distarch glycerine",
+      "eNumber": "E1441",
+      "synonyms": [
+        "E1441",
+        "Hydroxy propyl distarch glycerine"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967235"
+    },
+    {
+      "title": "Hydroxypropyl cellulose",
+      "eNumber": "E463",
+      "synonyms": [
+        "E463",
+        "Hydroxypropyl cellulose",
+        "Hydroxypropylcellulose"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Hydroxypropyl cellulose -HPC- is a derivative of cellulose with both water solubility and organic solubility.  It is used as an excipient, and topical ophthalmic protectant and lubricant.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Hydroxypropyl_cellulose",
+      "wikidata": "Q724426"
+    },
+    {
+      "title": "Hydroxypropyl distarch phosphate",
+      "eNumber": "E1442",
+      "synonyms": [
+        "E1442",
+        "Hydroxypropyl distarch phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Hydroxypropyl distarch phosphate -HDP- is a modified resistant starch. It is currently used as a food additive -INS number 1442-. It is approved for use in the European Union -listed as E1442-, the United States, Australia, Taiwan, and New Zealand.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Hydroxypropyl_distarch_phosphate",
+      "wikidata": "Q10528966"
+    },
+    {
+      "title": "Hydroxypropyl methyl cellulose",
+      "eNumber": "E464",
+      "synonyms": [
+        "E464",
+        "Hydroxypropyl methyl cellulose",
+        "hypromellose",
+        "hydroxypropyl methylcellulose",
+        "HPMC",
+        "hydroxypropylmethylcellulose",
+        "hydroxy propyl methyl cellulose"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Hypromellose -INN-, short for hydroxypropyl methylcellulose -HPMC-, is a semisynthetic, inert, viscoelastic polymer used as eye drops, as well as an excipient and controlled-delivery component in oral medicaments, found in a variety of commercial products.As a food additive, hypromellose is an emulsifier, thickening and suspending agent, and an alternative to animal gelatin. Its Codex Alimentarius code -E number- is E464.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Hypromellose",
+      "wikidata": "Q423846"
+    },
+    {
+      "title": "Hydroxypropyl starch",
+      "eNumber": "E1440",
+      "synonyms": [
+        "E1440",
+        "Hydroxypropyl starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q1640437"
+    },
+    {
+      "title": "Indanthrene blue RS",
+      "eNumber": "E130",
+      "synonyms": [
+        "E130",
+        "Indanthrene blue RS",
+        "Indanthrone blue",
+        "indanthrene"
+      ],
+      "functions": [],
+      "description": "Indanthrone blue, also called indanthrene, is an organic dye made from 2-aminoanthraquinone treated with potassium hydroxide in the presence of a potassium salt. It is a pigment that can be used in the following mediums: acrylic, alkalyd, casein, encaustic, fresco, gouache, linseed oil, tempera, pastel, and watercolor painting. It is used to dye unmordanted cotton and as a pigment in quality paints and enamels. As a food dye, it has E number E130, but it is not approved for use in either the United States or the European Union. The pigment has a color index name of PB60. Indanthrene Blue RS was patented in 1901 by Rene Bohn as the first anthraquinone vat dye, one of the dyes with very good fastness to light and washing.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Indanthrone_blue",
+      "wikidata": "Q185929"
+    },
+    {
+      "title": "Indigotine",
+      "eNumber": "E132",
+      "synonyms": [
+        "E132",
+        "Indigotine",
+        "indigo carmine",
+        "FD&C Blue 2",
+        "FD and C Blue 2",
+        "C.I. Food Blue 2",
+        "Blue 2 lake",
+        "Blue 2"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Indigo carmine, or 5‚5′-indigodisulfonic acid sodium salt, is an organic salt derived from indigo by sulfonation, which renders the compound soluble in water.  It is approved for use as a food colorant in the U.S and E.U., It has the E number E132.   It is also a pH indicator.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Indigo_carmine",
+      "wikidata": "Q410120"
+    },
+    {
+      "title": "Inorganic salts",
+      "eNumber": "",
+      "synonyms": [
+        "Inorganic salts"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Inosinic acid",
+      "eNumber": "E630",
+      "synonyms": [
+        "E630",
+        "Inosinic acid"
+      ],
+      "functions": [],
+      "description": "Inosinic acid or inosine monophosphate -IMP- is a nucleoside monophosphate. Widely used as a flavor enhancer, it is typically obtained from chicken byproducts or other meat industry waste.  Inosinic acid is important in metabolism.  It is the ribonucleotide of hypoxanthine and the first nucleotide formed during the synthesis of purine.  It is formed by the deamination of adenosine monophosphate, and is hydrolysed to inosine. IMP is an intermediate ribonucleoside monophosphate in purine metabolism. The enzyme deoxyribonucleoside triphosphate pyrophosphohydrolase, encoded by YJR069C in Saccharomyces cerevisiae and containing -d-ITPase and -d-XTPase activities, hydrolyzes inosine triphosphate -ITP- releasing pyrophosphate and IMP.Important derivatives of inosinic acid include purine nucleotides found in nucleic acids and adenosine triphosphate, which is used to store chemical energy in muscle and other tissues. In the food industry, inosinic acid and its salts such as disodium inosinate are used as flavor enhancers.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Inosinic_acid",
+      "wikidata": "Q255933"
+    },
+    {
+      "title": "Invertase",
+      "eNumber": "E1103",
+      "synonyms": [
+        "E1103",
+        "Invertase"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "Invertase is an enzyme that catalyzes the hydrolysis -breakdown- of sucrose -table sugar- into fructose and glucose. Alternative names for invertase include EC 3.2.1.26, saccharase, glucosucrase, beta-h-fructosidase, beta-fructosidase, invertin, sucrase, maxinvert L 1000, fructosylinvertase, alkaline invertase, acid invertase, and the systematic name: beta-fructofuranosidase.  The resulting mixture of fructose and glucose is called inverted sugar syrup. Related to invertases are sucrases. Invertases and sucrases hydrolyze sucrose to give the same mixture of glucose and fructose. Invertases cleave the O-C-fructose- bond, whereas the sucrases cleave the O-C-glucose- bond.For industrial use, invertase is usually derived from yeast. It is also synthesized by bees, which use it to make honey from nectar. Optimal temperature at which the rate of reaction is at its greatest is 60 °C and an optimum pH of 4.5.  Typically, sugar is inverted with sulfuric acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Invertase",
+      "wikidata": "Q419189"
+    },
+    {
+      "title": "iron gluconate",
+      "eNumber": "E579",
+      "synonyms": [
+        "E579",
+        "iron gluconate",
+        "ferrous gluconate"
+      ],
+      "functions": [],
+      "description": "IronII gluconate, or ferrous gluconate, is a black compound often used as an iron supplement. It is the iron-II- salt of gluconic acid.  It is marketed under brand names such as Fergon, Ferralet and Simron.",
+      "wikipedia": "https://en.wikipedia.org/wiki/IronII_gluconate",
+      "wikidata": "Q421291"
+    },
+    {
+      "title": "Iron oxides and iron hydroxides",
+      "eNumber": "E172",
+      "synonyms": [
+        "E172",
+        "Iron oxides and iron hydroxides"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q3045754"
+    },
+    {
+      "title": "Isobutane",
+      "eNumber": "E943B",
+      "synonyms": [
+        "E943b",
+        "Isobutane"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "isomalt",
+      "eNumber": "E953",
+      "synonyms": [
+        "E953",
+        "isomalt"
+      ],
+      "functions": [
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Isomalt is a sugar substitute, a type of sugar alcohol used primarily for its sugar-like physical properties. It has little to no impact on blood sugar levels, and does not stimulate the release of insulin. It also does not promote tooth decay, i.e. is tooth-friendly.  Its energy value is 2 kcal/g, half that of sugars. However, like most sugar alcohols, it carries a risk of gastric distress, including flatulence and diarrhea, when consumed in large quantities -above about 20-30 g per day-. Isomalt may prove upsetting to the intestinal tract because it is incompletely absorbed in the small intestine, and when polyols pass into the large intestine, they can cause osmotically induced diarrhea and stimulate the gut flora, causing flatulence. As with other dietary fibers, regular consumption of isomalt can lead to desensitisation, decreasing the risk of intestinal upset. Isomalt can be blended with high-intensity sweeteners such as sucralose, giving a mixture that has the same sweetness as sugar.  Isomalt is an equimolar mixture of two mutually diastereomeric disaccharides, each composed of two sugars: glucose and mannitol -α-D-glucopyranosido-1‚6-mannitol- and also glucose and sorbitol -α-D-glucopyranosido-1‚6-sorbitol-. Complete hydrolysis of isomalt yields glucose -50%-, sorbitol -25%-, and mannitol -25%-. It is an odorless, white, crystalline substance containing about 5% water of crystallisation. Isomalt has a minimal cooling effect -positive heat of solution-, lower than many other sugar alcohols, in particular, xylitol and erythritol. Isomalt is manufactured in a two-stage process in which sucrose is first transformed into isomaltulose, a reducing disaccharide -6-O-α-D-glucopyranosido-D-fructose-. The isomaltulose is then hydrogenated, using a Raney nickel catalyst. The final product — isomalt — is an equimolar composition of 6-O-α-D-glucopyranosido-D-sorbitol -1‚6-GPS- and 1-O-α-D-glucopyranosido-D-mannitol-dihydrate -1‚1-GPM-dihydrate-. Isomalt has been approved for use in the United States since 1990. It is also permitted for use in Australia, New Zealand, Canada, Mexico, Iran, the European Union, and other countries. Isomalt is widely used for the production of sugar-free candy, especially hard-boiled candy, because it resists crystallisation much better than the standard combinations of sucrose and corn syrup. It is used in sugar sculpture for the same reason.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Isomalt",
+      "wikidata": "Q412068"
+    },
+    {
+      "title": "Isomaltose",
+      "eNumber": "",
+      "synonyms": [
+        "isomaltose"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Isomaltose",
+      "wikidata": "Q28487684"
+    },
+    {
+      "title": "Isopropyl citrates",
+      "eNumber": "E384",
+      "synonyms": [
+        "E384",
+        "Isopropyl citrates"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative",
+        "sequestrant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Karaya-gum",
+      "eNumber": "E416",
+      "synonyms": [
+        "E416",
+        "Karaya-gum",
+        "Katilo",
+        "Kadaya",
+        "Gum sterculia",
+        "Sterculia",
+        "Karaya",
+        "gum karaya",
+        "Kullo"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Gum karaya or gum sterculia, also known as Indian gum tragacanth, is a vegetable gum produced as an exudate by trees of the genus Sterculia. Chemically, gum karaya is an acid polysaccharide composed of the sugars galactose, rhamnose and galacturonic acid.  It is used as a thickener and emulsifier in foods, as a laxative, and as a denture adhesive. It is also used to adulterate  Gum tragacanth due to their similar physical characteristics. As a food additive it has E number E416. Gum karaya can be obtained from the tree Sterculia urens. It is a valuable substance and is traditionally tapped by cutting or peeling back the bark, or by making deep gashes at the base of the trunk with an axe. These crude methods of extraction often resulted in the death of the tree, but it has been found that application of the plant growth regulator ethephon stimulates the production of gum, and when used in carefully controlled amounts, increases gum yield and enhances healing of the wounds and survival of the tree.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Gum_karaya",
+      "wikidata": "Q421167"
+    },
+    {
+      "title": "Konjac",
+      "eNumber": "E425",
+      "synonyms": [
+        "E425",
+        "Konjac"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Konjac glucomannan",
+      "eNumber": "E425II",
+      "synonyms": [
+        "E425ii",
+        "Konjac glucomannan"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Konjac gum",
+      "eNumber": "E425I",
+      "synonyms": [
+        "E425i",
+        "Konjac gum",
+        "Konjak gum"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "l-cysteine",
+      "eNumber": "E920",
+      "synonyms": [
+        "E920",
+        "l-cysteine",
+        "L-cysteine hydrochloride",
+        "L-Cysteine",
+        "L-2-Amino-3-mercaptopropionic acid",
+        "L-Cys",
+        "(R)-2-Amino-3-mercaptopropanoic acid",
+        "(2R)-2-amino-3-sulfanylpropanoic acid",
+        "(2R)-2-amino-3-mercaptopropanoic acid"
+      ],
+      "functions": [],
+      "description": "Cysteine -symbol Cys or C; - is a semi-essential proteinogenic amino acid with the formula HO2CCH-NH2-CH2SH. The thiol side chain in cysteine often participates in enzymatic reactions, as a nucleophile.  The thiol is susceptible to oxidation to give the disulfide derivative cystine, which serves an important structural role in many proteins. When used as a food additive, it has the E number E920.  It is encoded by the codons UGU and UGC. Cysteine has the same structure as serine, but with one of its oxygen atoms replaced by sulfur; replacing it with selenium gives selenocysteine. -Like other natural proteinogenic amino acids cysteine has -L- chirality in the older D/L notation based on homology to D and L glyceraldehyde.  In the newer R/S system of designating chirality, based on the atomic numbers of atoms near the asymmetric carbon, cysteine -and selenocysteine- have R chirality, because of the presence of sulfur -resp. selenium- as a second neighbor to the asymmetric carbon.  The remaining chiral amino acids, having lighter atoms in that position, have S chirality.-",
+      "wikipedia": "https://en.wikipedia.org/wiki/Cysteine",
+      "wikidata": "Q186474"
+    },
+    {
+      "title": "L-cysteine hydrochloride monohydrate",
+      "eNumber": "E921",
+      "synonyms": [
+        "E921",
+        "L-cysteine hydrochloride monohydrate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "L(+)-tartaric acid",
+      "eNumber": "E334",
+      "synonyms": [
+        "E334",
+        "L(+)-tartaric acid",
+        "tartaric acid",
+        "2‚3-dihydroxybutanedioic acid",
+        "2‚3-dihydroxysuccinic acid",
+        "threaric acid",
+        "racemic acid",
+        "uvic acid",
+        "paratartaric acid"
+      ],
+      "functions": [
+        "antioxidant",
+        "sequestrant"
+      ],
+      "description": "Tartaric acid is a white, crystalline organic acid that occurs naturally in many fruits, most notably in grapes, but also in  bananas, tamarinds, and citrus.  Its salt, potassium bitartrate, commonly known as cream of tartar, develops naturally in the process of winemaking. It is commonly mixed with sodium bicarbonate and is sold as baking powder used as a leavening agent in food preparation.  The acid itself is added to foods as an antioxidant and to impart its distinctive sour taste. Tartaric is an alpha-hydroxy-carboxylic acid, is diprotic and aldaric in acid characteristics, and is a dihydroxyl derivative of succinic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tartaric_acid",
+      "wikidata": "Q194322"
+    },
+    {
+      "title": "Lactic acid",
+      "eNumber": "E270",
+      "synonyms": [
+        "E270",
+        "Lactic acid",
+        "milk acid",
+        "2-Hydroxypropanoic acid"
+      ],
+      "functions": [],
+      "description": "Lactic acid is an organic compound with the formula CH3CH-OH-COOH.  In its solid state, it is white and water-soluble. In its liquid state, it is colorless. It is produced both naturally and synthetically. With a hydroxyl group adjacent to the carboxyl group, lactic acid is classified as an alpha-hydroxy acid -AHA-.  In the form of its conjugate base called lactate, it plays a role in several biochemical processes. In solution, it can ionize a proton from the carboxyl group, producing the lactate ion CH3CH-OH-CO−2. Compared to acetic acid, its pKa is 1 unit less, meaning lactic acid deprotonates ten times more easily than acetic acid does. This higher acidity is the consequence of the intramolecular hydrogen bonding between the α-hydroxyl and the carboxylate group. Lactic acid is chiral, consisting of two optical isomers. One is known as L--+--lactic acid or -S--lactic acid and the other, its mirror image, is D--−--lactic acid or -R--lactic acid. A mixture of the two in equal amounts is called DL-lactic acid, or racemic lactic acid. Lactic acid is hygroscopic. DL-lactic acid is miscible with water and with ethanol above its melting point which is around 17 or 18 °C. D-lactic acid and L-lactic acid have a higher melting point. In animals, L-lactate is constantly produced from pyruvate via the enzyme lactate dehydrogenase -LDH- in a process of fermentation during normal metabolism and exercise. It does not increase in concentration until the rate of lactate production exceeds the rate of lactate removal, which is governed by a number of factors, including monocarboxylate transporters, concentration and isoform of LDH, and oxidative capacity of tissues. The concentration of blood lactate is usually 1–2 mM at rest, but can rise to over 20 mM during intense exertion and as high as 25 mM afterward. In addition to other biological roles, L-lactic acid is the primary endogenous agonist of hydroxycarboxylic acid receptor 1 -HCA1-, which is a Gi/o-coupled G protein-coupled receptor -GPCR-.In industry, lactic acid fermentation is performed by lactic acid bacteria, which convert simple carbohydrates such as glucose, sucrose, or galactose to lactic acid. These bacteria can also grow in the mouth; the acid they produce is responsible for the tooth decay known as caries. In medicine, lactate is one of the main components of lactated Ringer's solution and Hartmann's solution. These intravenous fluids consist of sodium and potassium cations along with lactate and chloride anions in solution with distilled water, generally in concentrations isotonic with human blood. It is most commonly used for fluid resuscitation after blood loss due to trauma, surgery, or burns.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lactic_acid",
+      "wikidata": "Q56626856"
+    },
+    {
+      "title": "Lactic acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472B",
+      "synonyms": [
+        "E472b",
+        "Lactic acid esters of mono- and diglycerides of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967238"
+    },
+    {
+      "title": "Lactitol",
+      "eNumber": "E966",
+      "synonyms": [
+        "E966",
+        "Lactitol",
+        "Lactit",
+        "Lactositol"
+      ],
+      "functions": [
+        "emulsifier",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Lactitol is a sugar alcohol used as a replacement bulk sweetener for low calorie foods with approximately 40% of the sweetness of sugar.  It is also used medically as a laxative.  Lactitol is produced by two manufacturers, Danisco and Purac Biochem.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lactitol",
+      "wikidata": "Q415020"
+    },
+    {
+      "title": "Lactylated fatty acid esters of glycerol and propane-1",
+      "eNumber": "E478",
+      "synonyms": [
+        "E478",
+        "Lactylated fatty acid esters of glycerol and propane-1"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18935693"
+    },
+    {
+      "title": "Lanolin",
+      "eNumber": "E913",
+      "synonyms": [
+        "E913",
+        "Lanolin",
+        "sheep wool grease",
+        "wool wax",
+        "wool grease"
+      ],
+      "functions": [],
+      "description": "Lanolin -from Latin lāna ‘wool', and oleum ‘oil'-, also called wool wax or wool grease, is a wax secreted by the sebaceous glands of wool-bearing animals. Lanolin used by humans comes from domestic sheep breeds that are raised specifically for their wool. Historically, many pharmacopoeias have referred to lanolin as wool fat -adeps lanae-; however, as lanolin lacks glycerides -glycerol esters-, it is not a true fat. Lanolin primarily consists of sterol esters instead. Lanolin's waterproofing property aids sheep in shedding water from their coats. Certain breeds of sheep produce large amounts of lanolin. Lanolin's role in nature is to protect wool and skin from climate and the environment; it also plays a role in skin -integumental- hygiene. Lanolin and its derivatives are used in the protection, treatment and beautification of human skin.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lanolin",
+      "wikidata": "Q911098"
+    },
+    {
+      "title": "Lecithin",
+      "eNumber": "E322I",
+      "synonyms": [
+        "E322i",
+        "Lecithin"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier"
+      ],
+      "description": "Lecithin -UK: , US: , from the Greek lekithos, \"egg yolk\"- is a generic term to designate any group of yellow-brownish fatty substances occurring in animal and plant tissues, which are amphiphilic – they attract both water and fatty substances -and so are both hydrophilic and lipophilic-, and are used for smoothing food textures, dissolving powders -emulsifying-, homogenizing liquid mixtures, and repelling sticking materials.Lecithins are mixtures of glycerophospholipids including phosphatidylcholine, phosphatidylethanolamine, phosphatidylinositol, phosphatidylserine, and phosphatidic acid.Lecithin was first isolated in 1845 by the French chemist and pharmacist Theodore Gobley. In 1850, he named the phosphatidylcholine lécithine. Gobley originally isolated lecithin from egg yolk—λέκιθος lekithos is \"egg yolk\" in Ancient Greek—and established the complete chemical formula of phosphatidylcholine in 1874; in between, he had demonstrated the presence of lecithin in a variety of biological matters, including venous blood, in human lungs, bile, human brain tissue, fish eggs, fish roe, and chicken and sheep brain. Lecithin can easily be extracted chemically using solvents such as hexane, ethanol, acetone, petroleum ether, benzene, etc., or extraction can be done mechanically. It is usually available from sources such as soybeans, eggs, milk, marine sources, rapeseed, cottonseed, and sunflower. It has low solubility in water, but is an excellent emulsifier. In aqueous solution, its phospholipids can form either liposomes, bilayer sheets, micelles, or lamellar structures, depending on hydration and temperature. This results in a type of surfactant that usually is classified as amphipathic. Lecithin is sold as a food additive and dietary supplement. In cooking, it is sometimes used as an emulsifier and to prevent sticking, for example in nonstick cooking spray.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lecithin",
+      "wikidata": "Q241595"
+    },
+    {
+      "title": "Lecithin citrate",
+      "eNumber": "E344",
+      "synonyms": [
+        "E344",
+        "Lecithin citrate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081794"
+    },
+    {
+      "title": "Lecithins",
+      "eNumber": "E322",
+      "synonyms": [
+        "E322",
+        "Lecithins",
+        "Phosphatides"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier"
+      ],
+      "description": "Lecithin -UK: , US: , from the Greek lekithos, \"egg yolk\"- is a generic term to designate any group of yellow-brownish fatty substances occurring in animal and plant tissues, which are amphiphilic – they attract both water and fatty substances -and so are both hydrophilic and lipophilic-, and are used for smoothing food textures, dissolving powders -emulsifying-, homogenizing liquid mixtures, and repelling sticking materials.Lecithins are mixtures of glycerophospholipids including phosphatidylcholine, phosphatidylethanolamine, phosphatidylinositol, phosphatidylserine, and phosphatidic acid.Lecithin was first isolated in 1845 by the French chemist and pharmacist Theodore Gobley. In 1850, he named the phosphatidylcholine lécithine. Gobley originally isolated lecithin from egg yolk—λέκιθος lekithos is \"egg yolk\" in Ancient Greek—and established the complete chemical formula of phosphatidylcholine in 1874; in between, he had demonstrated the presence of lecithin in a variety of biological matters, including venous blood, in human lungs, bile, human brain tissue, fish eggs, fish roe, and chicken and sheep brain. Lecithin can easily be extracted chemically using solvents such as hexane, ethanol, acetone, petroleum ether, benzene, etc., or extraction can be done mechanically. It is usually available from sources such as soybeans, eggs, milk, marine sources, rapeseed, cottonseed, and sunflower. It has low solubility in water, but is an excellent emulsifier. In aqueous solution, its phospholipids can form either liposomes, bilayer sheets, micelles, or lamellar structures, depending on hydration and temperature. This results in a type of surfactant that usually is classified as amphipathic. Lecithin is sold as a food additive and dietary supplement. In cooking, it is sometimes used as an emulsifier and to prevent sticking, for example in nonstick cooking spray.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lecithin",
+      "wikidata": "Q241595"
+    },
+    {
+      "title": "Leucine",
+      "eNumber": "E641",
+      "synonyms": [
+        "E641",
+        "Leucine",
+        "L-Leucine"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Leucine",
+      "wikidata": "Q483745"
+    },
+    {
+      "title": "lipase",
+      "eNumber": "E1104",
+      "synonyms": [
+        "E1104",
+        "lipase"
+      ],
+      "functions": [],
+      "description": "A lipase -, - is any enzyme that catalyzes the hydrolysis of fats -lipids-. Lipases are a subclass of the esterases. Lipases perform essential roles in digestion, transport and processing of dietary lipids -e.g. triglycerides, fats, oils- in most, if not all, living organisms. Genes encoding lipases are even present in certain viruses.Most lipases act at a specific position on the glycerol backbone of a lipid substrate -A1, A2 or A3--small intestine-. For example, human pancreatic lipase -HPL-, which is the main enzyme that breaks down dietary fats in the human digestive system, converts triglyceride substrates found in ingested oils to monoglycerides and two fatty acids. Several other types of lipase activities exist in nature, such as phospholipases  and sphingomyelinases; however, these are usually treated separately from \"conventional\" lipases. Some lipases are expressed and secreted by pathogenic organisms during an infection. In particular, Candida albicans has a large number of different lipases, possibly reflecting broad-lipolytic activity, which may contribute to the persistence and virulence of C. albicans in human tissue.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lipase",
+      "wikidata": "Q380967"
+    },
+    {
+      "title": "Litholrubine bk",
+      "eNumber": "E180",
+      "synonyms": [
+        "E180",
+        "Litholrubine bk",
+        "CI Pigment Red 57",
+        "Rubinpigment",
+        "Pigment Rubine",
+        "Lithol rubine bk"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q427230"
+    },
+    {
+      "title": "Locust bean gum",
+      "eNumber": "E410",
+      "synonyms": [
+        "E410",
+        "Locust bean gum",
+        "Carob bean gum",
+        "Carob gum",
+        "garrofin gum",
+        "peruvian carob gum"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Locust bean gum -LBG, also known as carob gum, carob bean gum, carobin, E410- is a thickening agent and a gelling agent used in food technology.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Locust_bean_gum",
+      "wikidata": "Q221391"
+    },
+    {
+      "title": "Lutein",
+      "eNumber": "E161B",
+      "synonyms": [
+        "E161b",
+        "Lutein",
+        "Mixed Carotenoids",
+        "Xanthophyll",
+        "tagete extract"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lutein",
+      "wikidata": "Q422067"
+    },
+    {
+      "title": "Lycopene",
+      "eNumber": "E160D",
+      "synonyms": [
+        "E160d",
+        "Lycopene"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Lycopene -from the neo-Latin Lycopersicum, the tomato species- is a bright red carotene and carotenoid pigment and phytochemical found in tomatoes and other red fruits and vegetables, such as red carrots, watermelons, gac, and papayas, but it is not in strawberries or cherries. Although lycopene is chemically a carotene, it has no vitamin A activity. Foods that are not red may also contain lycopene, such as asparagus and parsley.In plants, algae, and other photosynthetic organisms, lycopene is an intermediate in the biosynthesis of many carotenoids, including beta-carotene, which is responsible for yellow, orange, or red pigmentation, photosynthesis, and photoprotection. Like all carotenoids, lycopene is a tetraterpene. It is insoluble in water. Eleven conjugated double bonds give lycopene its deep red color. Owing to the strong color, lycopene is useful as a food coloring -registered as E160d- and is approved for use in the USA, Australia and New Zealand -registered as 160d- and the European Union.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lycopene",
+      "wikidata": "Q208130"
+    },
+    {
+      "title": "Lysozyme",
+      "eNumber": "E1105",
+      "synonyms": [
+        "E1105",
+        "Lysozyme",
+        "Lysozyme hydrochloride",
+        "E 1105",
+        "E-1105"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lysozyme",
+      "wikidata": "Q21114915"
+    },
+    {
+      "title": "Magnesium carbonate",
+      "eNumber": "E504I",
+      "synonyms": [
+        "E504i",
+        "Magnesium carbonate"
+      ],
+      "functions": [
+        "carrier"
+      ],
+      "description": "Magnesium carbonate, MgCO3 -archaic name magnesia alba-, is an inorganic salt that is a white solid. Several hydrated and basic forms of magnesium carbonate also exist as minerals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_carbonate",
+      "wikidata": "Q407931"
+    },
+    {
+      "title": "Magnesium carbonates",
+      "eNumber": "E504",
+      "synonyms": [
+        "E504",
+        "Magnesium carbonates"
+      ],
+      "functions": [
+        "carrier"
+      ],
+      "description": "Magnesium carbonate, MgCO3 -archaic name magnesia alba-, is an inorganic salt that is a white solid. Several hydrated and basic forms of magnesium carbonate also exist as minerals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_carbonate",
+      "wikidata": "Q407931"
+    },
+    {
+      "title": "Magnesium chloride",
+      "eNumber": "E511",
+      "synonyms": [
+        "E511",
+        "Magnesium chloride"
+      ],
+      "functions": [
+        "stabiliser",
+        "coagulant"
+      ],
+      "description": "Magnesium chloride is the name for the chemical compound with the formula MgCl2 and its various hydrates MgCl2-H2O-x. These salts are typical ionic halides, being highly soluble in water. The hydrated magnesium chloride can be extracted from brine or sea water. In North America, magnesium chloride is produced primarily from Great Salt Lake brine. It is extracted in a similar process from the Dead Sea in the Jordan Valley. Magnesium chloride, as the natural mineral bischofite, is also extracted -by solution mining- out of ancient seabeds, for example, the Zechstein seabed in northwest Europe. Some magnesium chloride is made from solar evaporation of seawater. Anhydrous magnesium chloride is the principal precursor to magnesium metal, which is produced on a large scale. Hydrated magnesium chloride is the form most readily available.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_chloride",
+      "wikidata": "Q265414"
+    },
+    {
+      "title": "Magnesium citrate",
+      "eNumber": "E345",
+      "synonyms": [
+        "E345",
+        "Magnesium citrate"
+      ],
+      "functions": [],
+      "description": "Magnesium citrate is a magnesium preparation in salt form with citric acid in a 1:1 ratio -1 magnesium atom per citrate molecule-.  The name \"magnesium citrate\" is ambiguous and sometimes may refer to other salts such as trimagnesium citrate which has a magnesium:citrate ratio of 3:2. Magnesium citrate is used medicinally as a saline laxative and to completely empty the bowel prior to a major surgery or colonoscopy. It is available without a prescription, both as a generic and under various brand names. It is also used in the pill form as a magnesium dietary supplement. It contains 11.23% magnesium by weight. Compared to trimagnesium citrate, it is much more water-soluble, less alkaline, and contains less magnesium. As a food additive, magnesium citrate is used to regulate acidity and is known as E number E345.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_citrate",
+      "wikidata": "Q45044"
+    },
+    {
+      "title": "Magnesium diglutamate",
+      "eNumber": "E625",
+      "synonyms": [
+        "E625",
+        "Magnesium diglutamate"
+      ],
+      "functions": [],
+      "description": "Magnesium diglutamate is a compound with formula Mg-C5H8NO4-2. It is a magnesium acid salt of glutamic acid. It has the E number E625 and is used in foods as a flavor enhancer.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_diglutamate",
+      "wikidata": "Q1821120"
+    },
+    {
+      "title": "Magnesium Gluconate",
+      "eNumber": "E580",
+      "synonyms": [
+        "E580",
+        "Magnesium Gluconate"
+      ],
+      "functions": [],
+      "description": "Magnesium gluconate is a compound with formula MgC12H22O14. It is the magnesium salt of gluconic acid. According to scientific research, magnesium gluconate shows the highest level of bioavailability of any magnesium salt and is recommended as the optimal salt for human supplementation although of the 10 salts studied, all increased Magnesium levels significantly.It has E number \"E580\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_gluconate",
+      "wikidata": "Q6731392"
+    },
+    {
+      "title": "Magnesium hydroxide",
+      "eNumber": "E528",
+      "synonyms": [
+        "E528",
+        "Magnesium hydroxide"
+      ],
+      "functions": [],
+      "description": "Magnesium hydroxide is the inorganic compound with the chemical formula Mg-OH-2. It occurs in nature as the mineral brucite. It is a white solid with low solubility in water -Ksp = 5.61×10−12-. Magnesium hydroxide is a common component of antacids, such as milk of magnesia, as well as laxatives.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_hydroxide",
+      "wikidata": "Q407548"
+    },
+    {
+      "title": "Magnesium hydroxide carbonate",
+      "eNumber": "E504II",
+      "synonyms": [
+        "E504ii",
+        "Magnesium hydroxide carbonate"
+      ],
+      "functions": [
+        "carrier"
+      ],
+      "description": "Magnesium carbonate, MgCO3 -archaic name magnesia alba-, is an inorganic salt that is a white solid. Several hydrated and basic forms of magnesium carbonate also exist as minerals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_carbonate",
+      "wikidata": "Q407931"
+    },
+    {
+      "title": "Magnesium lactate",
+      "eNumber": "E329",
+      "synonyms": [
+        "E329",
+        "Magnesium lactate"
+      ],
+      "functions": [],
+      "description": "Magnesium lactate, the magnesium salt of lactic acid, is a mineral supplement. Added to some food and beverages as an acidity regulator and labeled as E329.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_lactate",
+      "wikidata": "Q594836"
+    },
+    {
+      "title": "Magnesium oxide",
+      "eNumber": "E530",
+      "synonyms": [
+        "E530",
+        "Magnesium oxide",
+        "magnesia"
+      ],
+      "functions": [],
+      "description": "Magnesium oxide -MgO-, or magnesia, is a white hygroscopic solid mineral that occurs naturally as periclase and is a source of magnesium -see also oxide-. It has an empirical formula of MgO and consists of a lattice of Mg2+ ions and O2− ions held together by ionic bonding. Magnesium hydroxide forms in the presence of water -MgO + H2O → Mg-OH-2-, but it can be reversed by heating it to separate moisture. Magnesium oxide was historically known as magnesia alba -literally, the white mineral from magnesia – other sources give magnesia alba as MgCO3-, to differentiate it from magnesia negra, a black mineral containing what is now known as manganese. While \"magnesium oxide\" normally refers to MgO, magnesium peroxide MgO2 is also known as a compound. According to evolutionary crystal structure prediction, MgO2 is thermodynamically stable at pressures above 116 GPa -gigapascals-, and a semiconducting suboxide Mg3O2 is thermodynamically stable above 500 GPa. Because of its stability, MgO is used as a model system for investigating vibrational properties of crystals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_oxide",
+      "wikidata": "Q214769"
+    },
+    {
+      "title": "Magnesium phosphates",
+      "eNumber": "E343",
+      "synonyms": [
+        "E343",
+        "Magnesium phosphates",
+        "magnesium phosphates",
+        "E 343",
+        "E-343"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_phosphate",
+      "wikidata": "Q2634889 # Q723683"
+    },
+    {
+      "title": "Magnesium pyrophosphate",
+      "eNumber": "E546",
+      "synonyms": [
+        "E546",
+        "Magnesium pyrophosphate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Magnesium salts of fatty acids",
+      "eNumber": "E470B",
+      "synonyms": [
+        "E470b",
+        "Magnesium salts of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Magnesium silicates",
+      "eNumber": "E553",
+      "synonyms": [
+        "E553",
+        "Magnesium silicates",
+        "magnesium silicate"
+      ],
+      "functions": [
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Talc",
+      "wikidata": ""
+    },
+    {
+      "title": "Magnesium stearate",
+      "eNumber": "E572",
+      "synonyms": [
+        "E572",
+        "Magnesium stearate"
+      ],
+      "functions": [],
+      "description": "Magnesium stearate is the chemical compound with the formula Mg-C18H35O2-2. It is a soap, consisting of salt containing two equivalents of stearate -the anion of stearic acid- and one magnesium cation -Mg2+-.  Magnesium stearate is a white, water-insoluble powder. Its applications exploit its softness, insolubility in many solvents, and low toxicity. It is used as a release agent and as a component or lubricant in the production of pharmaceuticals and cosmetics.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_stearate",
+      "wikidata": "Q416713"
+    },
+    {
+      "title": "Magnesium sulphate",
+      "eNumber": "E518",
+      "synonyms": [
+        "E518",
+        "Magnesium sulphate",
+        "Epsom salts",
+        "magnesium sulfate"
+      ],
+      "functions": [],
+      "description": "Magnesium sulfate is an inorganic salt with the formula MgSO4-H2O-x where 0≤x≤7. It is often encountered as the heptahydrate sulfate mineral epsomite -MgSO4·7H2O-, commonly called Epsom salt. The overall global annual usage in the mid-1970s of the monohydrate was 2.3 million tons, of which the majority was used in agriculture.Epsom salt has been traditionally used as a component of bath salts. Epsom salt can also be used as a beauty product. Athletes use it to soothe sore muscles, while gardeners use it to improve crops. It has a variety of other uses: for example, Epsom salt is also effective in the removal of splinters.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Magnesium_sulfate",
+      "wikidata": "Q288266"
+    },
+    {
+      "title": "Malic acid",
+      "eNumber": "E296",
+      "synonyms": [
+        "E296",
+        "Malic acid",
+        "hydroxybutanedioic acid",
+        "l-malic acid"
+      ],
+      "functions": [],
+      "description": "Malic acid is an organic compound with the molecular formula C4H6O5. It is a dicarboxylic acid that is made by all living organisms, contributes to the pleasantly sour taste of fruits, and is used as a food additive. Malic acid has two stereoisomeric forms -L- and D-enantiomers-, though only the L-isomer exists naturally. The salts and esters of malic acid are known as malates. The malate anion is an intermediate in the citric acid cycle.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Malic_acid",
+      "wikidata": "Q190143"
+    },
+    {
+      "title": "maltitol",
+      "eNumber": "E965",
+      "synonyms": [
+        "E965",
+        "maltitol"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Maltitol is a sugar alcohol -a polyol- used as a sugar substitute. It has 75–90% of the sweetness of sucrose -table sugar- and nearly identical properties, except for browning. It is used to replace table sugar because it is half as caloric, does not promote tooth decay, and has a somewhat lesser effect on blood glucose.  In chemical terms, maltitol is known as 4-O-α-glucopyranosyl-D-sorbitol. It is used in commercial products under trade names such as Lesys, Maltisweet and SweetPearl.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Maltitol",
+      "wikidata": "Q423882"
+    },
+    {
+      "title": "Maltitol syrup",
+      "eNumber": "E965II",
+      "synonyms": [
+        "E965ii",
+        "Maltitol syrup"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Maltitol is a sugar alcohol -a polyol- used as a sugar substitute. It has 75–90% of the sweetness of sucrose -table sugar- and nearly identical properties, except for browning. It is used to replace table sugar because it is half as caloric, does not promote tooth decay, and has a somewhat lesser effect on blood glucose.  In chemical terms, maltitol is known as 4-O-α-glucopyranosyl-D-sorbitol. It is used in commercial products under trade names such as Lesys, Maltisweet and SweetPearl.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Maltitol",
+      "wikidata": "Q423882"
+    },
+    {
+      "title": "Maltol",
+      "eNumber": "E636",
+      "synonyms": [
+        "E636",
+        "Maltol"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Malvidin",
+      "eNumber": "E163C",
+      "synonyms": [
+        "E163c",
+        "Malvidin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Anthocyanins -also anthocyans; from Greek: ἄνθος -anthos- \"flower\" and κυάνεος/κυανοῦς kyaneos/kyanous \"dark blue\"- are water-soluble vacuolar pigments that, depending on their pH, may appear red, purple, or blue. Food plants rich in anthocyanins include the blueberry, raspberry, black rice, and black soybean, among many others that are red, blue, purple, or black. Some of the colors of autumn leaves are derived from anthocyanins.Anthocyanins belong to a parent class of molecules called flavonoids synthesized via the phenylpropanoid pathway. They occur in all tissues of higher plants, including leaves, stems, roots, flowers, and fruits. Anthocyanins are derived from anthocyanidins by adding sugars. They are odorless and moderately astringent. Although approved to color foods and beverages in the European Union, anthocyanins are not approved for use as a food additive because they have not been verified as safe when used as food or supplement ingredients. There is no conclusive evidence anthocyanins have any effect on human biology or diseases.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Anthocyanin",
+      "wikidata": "Q137220"
+    },
+    {
+      "title": "Mannitol",
+      "eNumber": "E421",
+      "synonyms": [
+        "E421",
+        "Mannitol"
+      ],
+      "functions": [
+        "humectant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Mannitol is a type of sugar alcohol which is also used as a medication. As a sugar, it is often used as a sweetener in diabetic food, as it is poorly absorbed from the intestines. As a medication, it is used to decrease pressure in the eyes, as in glaucoma, and to lower increased intracranial pressure. Medically, it is given by injection. Effects typically begin within 15 minutes and last up to 8 hours.Common side effects from medical use include electrolyte problems and dehydration. Other serious side effects may include worsening heart failure and kidney problems.  It is unclear if use is safe in pregnancy. Mannitol is in the osmotic diuretic family of medications and works by pulling fluid from the brain and eyes.The discovery of mannitol is attributed to Joseph Louis Proust in 1806. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. The wholesale cost in the developing world is about US$1.12 to 5.80 a dose. In the United States, a course of treatment costs $25 to 50. It was originally made from the flowering ash and called manna due to its supposed resemblance to the Biblical food. Mannitol is on the World Anti-Doping Agency's banned drug list due to concerns that it may mask other drugs.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Mannitol",
+      "wikidata": "Q407646"
+    },
+    {
+      "title": "Metatartaric acid",
+      "eNumber": "E353",
+      "synonyms": [
+        "E353",
+        "Metatartaric acid"
+      ],
+      "functions": [],
+      "description": "Metatartaric acid a polymeric lactone of variable composition obtained by heating tartaric acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Metatartaric_acid",
+      "wikidata": "Q17997708"
+    },
+    {
+      "title": "methyl cellulose",
+      "eNumber": "E461",
+      "synonyms": [
+        "E461",
+        "methyl cellulose",
+        "methylcellulose"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Methyl cellulose -or methylcellulose- is a chemical compound derived from cellulose. It is a hydrophilic white powder in pure form and dissolves in cold -but not in hot- water, forming a clear viscous solution or gel. It is sold under a variety of trade names and is used as a thickener and emulsifier in various food and cosmetic products, and also as a treatment of constipation. Like cellulose, it is not digestible, not toxic, and not an allergen.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Methyl_cellulose",
+      "wikidata": "Q416312"
+    },
+    {
+      "title": "Methyl glucoside-coconut oil ester",
+      "eNumber": "E489",
+      "synonyms": [
+        "E489",
+        "Methyl glucoside-coconut oil ester"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967245"
+    },
+    {
+      "title": "Methyl p-hydroxybenzoate",
+      "eNumber": "E218",
+      "synonyms": [
+        "E218",
+        "Methyl p-hydroxybenzoate",
+        "Methylparaben",
+        "methyl 4-hydroxybenzoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Methylparaben, also methyl paraben, one of the parabens, is a preservative with the chemical formula CH3-C6H4-OH-COO-. It is the methyl ester of p-hydroxybenzoic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Methylparaben",
+      "wikidata": "Q229987"
+    },
+    {
+      "title": "Microcrystalline cellulose",
+      "eNumber": "E460I",
+      "synonyms": [
+        "E460i",
+        "Microcrystalline cellulose"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Cellulose is an organic compound with the formula -C6H10O5-n, a polysaccharide consisting of a linear chain of several hundred to many thousands of β-1→4- linked D-glucose units. Cellulose is an important structural component of the primary cell wall of green plants, many forms of algae and the oomycetes. Some species of bacteria secrete it to form biofilms. Cellulose is the most abundant organic polymer on Earth.  The cellulose content of cotton fiber is 90%, that of wood is 40–50%, and that of dried hemp is approximately 57%.Cellulose is mainly used to produce paperboard and paper. Smaller quantities are converted into a wide variety of derivative products such as cellophane and rayon. Conversion of cellulose from energy crops into biofuels such as cellulosic ethanol is under development as a renewable fuel source. Cellulose for industrial use is mainly obtained from wood pulp and cotton.Some animals, particularly ruminants and termites, can digest cellulose with the help of symbiotic micro-organisms that live in their guts, such as Trichonympha. In human nutrition, cellulose is a non-digestible constituent of insoluble dietary fiber, acting as a hydrophilic bulking agent for feces and potentially aiding in defecation.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Microcrystalline_cellulose",
+      "wikidata": "Q80294"
+    },
+    {
+      "title": "Microcrystalline wax",
+      "eNumber": "E905CI",
+      "synonyms": [
+        "E905ci",
+        "Microcrystalline wax"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q579764"
+    },
+    {
+      "title": "mineral oil",
+      "eNumber": "E905A",
+      "synonyms": [
+        "E905a",
+        "mineral oil"
+      ],
+      "functions": [],
+      "description": "Microcrystalline waxes are a type of wax produced by de-oiling petrolatum, as part of the petroleum refining process. In contrast to the more familiar paraffin wax which contains mostly unbranched alkanes, microcrystalline wax contains a higher percentage of isoparaffinic -branched- hydrocarbons and naphthenic hydrocarbons. It is characterized by the fineness of its crystals in contrast to the larger crystal of paraffin wax. It consists of high molecular weight saturated aliphatic hydrocarbons. It is generally darker, more viscous, denser, tackier and more elastic than paraffin waxes, and has a higher molecular weight and melting point. The elastic and adhesive characteristics of microcrystalline waxes are related to the non-straight chain components which they contain. Typical microcrystalline wax crystal structure is small and thin, making them more flexible than paraffin wax. It is commonly used in cosmetic formulations. Microcrystalline waxes when produced by wax refiners are typically produced to meet a number of ASTM specifications. These include congeal point -ASTM D938-, needle penetration -D1321-, color -ASTM D6045-, and viscosity -ASTM D445-. Microcrystalline waxes can generally be put into two categories: \"laminating\" grades and \"hardening\" grades. The laminating grades typically have a melt point of 140-175 F -60 - 80 oC- and needle penetration of 25 or above. The hardening grades will range from about 175-200 F -80 - 93 oC-, and have a needle penetration of 25 or below. Color in both grades can range from brown to white, depending on the degree of processing done at the refinery level. Microcrystalline waxes are derived from the refining of the heavy distillates from lubricant oil production. This by-product must then be de-oiled at a wax refinery. Depending on the end use and desired specification, the product may then have its odor removed and color removed -which typically starts as a brown or dark yellow-. This is usually done by means of a filtration method or by hydro-treating the wax material.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Microcrystalline_wax",
+      "wikidata": "Q583582"
+    },
+    {
+      "title": "Mixed acetic and tartaric acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472F",
+      "synonyms": [
+        "E472f",
+        "Mixed acetic and tartaric acid esters of mono- and diglycerides of fatty acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967248"
+    },
+    {
+      "title": "Modified Starch",
+      "eNumber": "E14XX",
+      "synonyms": [
+        "E14XX",
+        "Modified Starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Mono- and diacetyltartaric acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472E",
+      "synonyms": [
+        "E472e",
+        "Mono- and diacetyltartaric acid esters of mono- and diglycerides of fatty acids",
+        "Mono- and diacetyl tartaric acid esters of mono- and diglycerides of fatty acids",
+        "DATEM",
+        "Mono- and diacetyltartaric esters of mono- and diglycerides of fatty acids",
+        "emulsifier E472e"
+      ],
+      "functions": [
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q409406"
+    },
+    {
+      "title": "Mono- and diglycerides of fatty acids",
+      "eNumber": "E471",
+      "synonyms": [
+        "E471",
+        "Mono- and diglycerides of fatty acids",
+        "Glyceryl monostearate",
+        "Glyceryl monopalmitate",
+        "Glyceryl monooleate",
+        "Monostearin",
+        "Monopalmitin",
+        "Monoolein",
+        "Mono and diglycerides"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Mono- and diglycerides of fatty acids -E471- refers to a food additive composed of diglycerides and monoglycerides which is used as an emulsifier. This mixture is also sometimes referred to as partial glycerides.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Mono-_and_diglycerides_of_fatty_acids",
+      "wikidata": "Q416711"
+    },
+    {
+      "title": "Mono- and diglycerides of vegetable fatty acids",
+      "eNumber": "",
+      "synonyms": [
+        "mono- and diglycerides of vegetable fatty acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Monoammonium glutamate",
+      "eNumber": "E624",
+      "synonyms": [
+        "E624",
+        "Monoammonium glutamate"
+      ],
+      "functions": [],
+      "description": "Monoammonium glutamate is a compound with formula NH4C5H8NO4. It is an ammonium acid salt of glutamic acid. It has the E number E624 and is used as a flavor enhancer.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monoammonium_glutamate",
+      "wikidata": "Q8213959"
+    },
+    {
+      "title": "Monocalcium citrate",
+      "eNumber": "E333I",
+      "synonyms": [
+        "E333i",
+        "Monocalcium citrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Calcium citrate is the calcium salt of citric acid.  It is commonly used as a food additive -E333-, usually as a preservative, but sometimes for flavor.  In this sense, it is similar to sodium citrate.   Calcium citrate is also found in some dietary calcium supplements -e.g. Citracal-. Calcium makes up 24.1% of calcium citrate -anhydrous- and 21.1% of calcium citrate -tetrahydrate- by mass. The tetrahydrate occurs in nature as the mineral Earlandite.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_citrate",
+      "wikidata": "Q420280"
+    },
+    {
+      "title": "Monocalcium phosphate",
+      "eNumber": "E341I",
+      "synonyms": [
+        "E341i",
+        "Monocalcium phosphate",
+        "Monobasic calcium phosphate",
+        "mono-calcium phosphate",
+        "monocalcium phosphate",
+        "E 341i",
+        "E-341i",
+        "E341 i"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Calcium phosphate is a family of materials and minerals containing calcium ions -Ca2+- together with inorganic phosphate anions.  Some so-called calcium phosphates contain oxide and hydroxide as well.  They are white solids of nutritious value.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monocalcium_phosphate",
+      "wikidata": "Q414673"
+    },
+    {
+      "title": "Monomagnesium phosphate",
+      "eNumber": "E343I",
+      "synonyms": [
+        "E343i",
+        "Monomagnesium phosphate",
+        "Magnesiumdihydrogenphosphate",
+        "Magnesiumphosphate",
+        "monobasic",
+        "magnesium phosphate"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monomagnesium_phosphate",
+      "wikidata": "Q4161317"
+    },
+    {
+      "title": "Monopotassium citrate",
+      "eNumber": "E332I",
+      "synonyms": [
+        "E332i",
+        "Monopotassium citrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Potassium citrate -also known as tripotassium citrate- is a potassium salt of citric acid with the molecular formula K3C6H5O7.  It is a white, hygroscopic crystalline powder. It is odorless with a saline taste. It contains 38.28% potassium by mass.  In the monohydrate form it is highly hygroscopic and deliquescent. As a food additive, potassium citrate is used to regulate acidity and is known as E number E332. Medicinally, it may be used to control kidney stones derived from either uric acid or cystine.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_citrate",
+      "wikidata": ""
+    },
+    {
+      "title": "Monopotassium glutamate",
+      "eNumber": "E622",
+      "synonyms": [
+        "E622",
+        "Monopotassium glutamate",
+        "Potassium glutamate"
+      ],
+      "functions": [],
+      "description": "Monopotassium glutamate -MPG- is a compound with formula KC5H8NO4. It is a potassium acid salt of glutamic acid. It has the E number E622 and is used in foods as a flavor enhancer.  It is a non-sodium MSG alternative.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monopotassium_glutamate",
+      "wikidata": "Q3029787"
+    },
+    {
+      "title": "Monopotassium phosphate",
+      "eNumber": "E340I",
+      "synonyms": [
+        "E340i",
+        "Monopotassium phosphate",
+        "Monobasic potassium phosphate",
+        "Monopotassium monophosphate",
+        "E 340i",
+        "E-340i",
+        "E340 i"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Potassium phosphate is a generic term for the salts of potassium and phosphate ions including: Monopotassium phosphate -KH2PO4- -Molar mass approx: 136 g/mol- Dipotassium phosphate -K2HPO4- -Molar mass approx: 174 g/mol- Tripotassium phosphate -K3PO4- -Molar mass approx: 212.27 g/mol-As food additives, potassium phosphates have the E number E340.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monopotassium_phosphate",
+      "wikidata": "Q415049"
+    },
+    {
+      "title": "Monopotassium tartrate",
+      "eNumber": "E336I",
+      "synonyms": [
+        "E336i",
+        "Monopotassium tartrate",
+        "monopotassic tartrate",
+        "Potassium bitartrate",
+        "potassium hydrogen tartrate",
+        "cream of tartar"
+      ],
+      "functions": [],
+      "description": "Potassium tartrate, dipotassium tartrate or argol has formula K2C4H4O6. It is the potassium salt of tartaric acid.  It is often confused with potassium bitartrate, also known as cream of tartar.  As a food additive, it shares the E number E336 with potassium bitartrate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_bitartrate",
+      "wikidata": "Q18745"
+    },
+    {
+      "title": "Monosodium citrate",
+      "eNumber": "E331I",
+      "synonyms": [
+        "E331i",
+        "Monosodium citrate"
+      ],
+      "functions": [
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Sodium citrate may refer to any of the sodium salts of citrate -though most commonly the third-:  Monosodium citrate Disodium citrate Trisodium citrateThe three forms of the salt are collectively known by the E number E331. Sodium citrates are used as acidity regulators in food and drinks, and also as emulsifiers for oils. They enable cheeses to melt without becoming greasy.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monosodium_citrate",
+      "wikidata": "Q4179018"
+    },
+    {
+      "title": "Monosodium glutamate",
+      "eNumber": "E621",
+      "synonyms": [
+        "E621",
+        "Monosodium glutamate",
+        "monosodium l-glutamate",
+        "Sodium glutamate",
+        "L-Glutamic acid‚ monosodium salt",
+        "Glutamate",
+        "MSG"
+      ],
+      "functions": [
+        "flavour-enhancer"
+      ],
+      "description": "Monosodium glutamate -MSG, also known as sodium glutamate- is the sodium salt of glutamic acid, one of the most abundant naturally occurring non-essential amino acids. Glutamic acid is found naturally in tomatoes, grapes, cheese, mushrooms and other foods.MSG is used in the food industry as a flavor enhancer with an umami taste that intensifies the meaty, savory flavor of food, as naturally occurring glutamate does in foods such as stews and meat soups. It was first prepared in 1908 by Japanese biochemist Kikunae Ikeda, who was trying to isolate and duplicate the savory taste of kombu, an edible seaweed used as a base for many Japanese soups. MSG as a flavor enhancer balances, blends, and rounds the perception of other tastes.The U.S. Food and Drug Administration has given MSG its generally recognized as safe -GRAS- designation. A popular belief is that large doses of MSG can cause headaches and other feelings of discomfort, known as \"Chinese restaurant syndrome,\" but double-blind tests fail to find evidence of such a reaction. The European Union classifies it as a food additive permitted in certain foods and subject to quantitative limits. MSG has the HS code 29224220 and the E number E621.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monosodium_glutamate",
+      "wikidata": "Q179678"
+    },
+    {
+      "title": "Monosodium phosphate",
+      "eNumber": "E339I",
+      "synonyms": [
+        "E339i",
+        "Monosodium phosphate",
+        "Monosodium monophosphate",
+        "Acid monosodium monophosphate",
+        "Monosodium orthophosphate",
+        "Monobasic sodium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "preservative",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium phosphate is a generic term for a variety of salts of sodium -Na+- and phosphate -PO43−-. Phosphate also forms families or condensed anions including di-, tri-, tetra-, and polyphosphates. Most of these salts are known in both anhydrous -water-free- and hydrated forms. The hydrates are more common than the anhydrous forms.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Monosodium_phosphate",
+      "wikidata": "Q415877"
+    },
+    {
+      "title": "Monosodium tartrate",
+      "eNumber": "E335I",
+      "synonyms": [
+        "E335i",
+        "Monosodium tartrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q836451"
+    },
+    {
+      "title": "Monostarch phosphate",
+      "eNumber": "E1410",
+      "synonyms": [
+        "E1410",
+        "Monostarch phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18631008"
+    },
+    {
+      "title": "Montanic acid esters",
+      "eNumber": "E912",
+      "synonyms": [
+        "E912",
+        "Montanic acid esters",
+        "Montan acid esters"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18935695"
+    },
+    {
+      "title": "Natamycin",
+      "eNumber": "E235",
+      "synonyms": [
+        "E235",
+        "Natamycin",
+        "Pimaracin"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Natamycin, also known as pimaricin, is an antifungal medication used to treat fungal infections around the eye. This includes infections of the eyelids, conjunctiva, and cornea. It is used as eyedrops. Natamycin is also used in the food industry as a preservative.Allergic reactions may occur. It is unclear if medical use during pregnancy or breastfeeding is safe. It is in the macrolide and polyene families of medications. It results in fungal death by altering the cell membrane.Natamycin was discovered in 1955 and approved for medical use in the United States in 1978. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. The wholesale cost in the developing world is between US$92.90 and 126.72 per 5-ml bottle as of 2015. It is produced by fermentation of the bacterium Streptomyces natalensis.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Natamycin",
+      "wikidata": "Q248466"
+    },
+    {
+      "title": "Natürliche Quellkohlensäure",
+      "eNumber": "",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Neohesperidine dihydrochalcone",
+      "eNumber": "E959",
+      "synonyms": [
+        "E959",
+        "Neohesperidine dihydrochalcone",
+        "Neohesperidin dihydrochalcone",
+        "Neohesperidine DC",
+        "NHDC"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Neohesperidin dihydrochalcone, sometimes abbreviated to neohesperidin DC or simply NHDC, is an artificial sweetener derived from citrus. It is particularly effective in masking the bitter tastes of other compounds found in citrus, including limonin and naringin. Industrially, it is produced by extracting neohesperidin from the bitter orange, and then hydrogenating this to make NHDC.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Neohesperidin_dihydrochalcone",
+      "wikidata": "Q424595"
+    },
+    {
+      "title": "Neotame",
+      "eNumber": "E961",
+      "synonyms": [
+        "E961",
+        "Neotame"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Neotame is an artificial sweetener made by NutraSweet that is between 7‚000 and 13‚000 times sweeter than sucrose -table sugar-. In the European Union, it is known by the E number E961.  It is moderately heat-stable, extremely potent, rapidly metabolized, completely eliminated, and does not appear to accumulate in the body.The major metabolic pathway is hydrolysis of the methyl ester by esterases that are present throughout the body, which yields de-esterified neotame and methanol.  Because only trace amounts of neotame are needed to sweeten foods, the amount of methanol derived from neotame is much lower than that found in common foods.The product is attractive to food manufacturers, as its use greatly lowers the cost of production compared to using sugar or high fructose corn syrup -due to the lower quantities needed to achieve the same sweetening-, while also benefitting the consumer by providing fewer \"empty\" sugar calories and a lower impact on blood sugar.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Neotame",
+      "wikidata": "Q415698"
+    },
+    {
+      "title": "Neutral methacrylate copolymer",
+      "eNumber": "E1206",
+      "synonyms": [
+        "E1206",
+        "Neutral methacrylate copolymer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Nicotinic acid",
+      "eNumber": "E375",
+      "synonyms": [
+        "E375",
+        "Nicotinic acid",
+        "Niacin",
+        "Nicotinamide"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Nisin",
+      "eNumber": "E234",
+      "synonyms": [
+        "E234",
+        "Nisin"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Nisin is a polycyclic antibacterial peptide produced by the bacterium Lactococcus lactis that is used as a food preservative. It has 34 amino acid residues, including the uncommon amino acids lanthionine -Lan-, methyllanthionine -MeLan-, didehydroalanine -Dha-, and didehydroaminobutyric acid -Dhb-. These unusual amino acids are introduced by posttranslational modification of the precursor peptide. In these reactions a ribosomally synthesized 57-mer is converted to the final peptide. The unsaturated amino acids originate from serine and threonine, and the enzyme-catalysed addition of cysteine residues to the didehydro amino acids result in the multiple -5- thioether bridges. Subtilin and epidermin are related to nisin. All are members of a class of molecules known as lantibiotics. In the food industry, nisin is obtained from the culturing of L. lactis on natural substrates, such as milk or dextrose, and it is not chemically synthesized. It was originally isolated in the late 1930s, and produced since the 1950s as Nisaplin from naturally occurring sources by Aplin and Barrett in laboratories in Beaminster in Dorset, and approved as an additive for food use in the USA in the late 1960s, although the Beaminster factory now is owned by DuPont.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Nisin",
+      "wikidata": "Q415798"
+    },
+    {
+      "title": "Nitrogen",
+      "eNumber": "E941",
+      "synonyms": [
+        "E941",
+        "Nitrogen",
+        "nitrogen E941"
+      ],
+      "functions": [
+        "propellent-gas"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Nitrogen",
+      "wikidata": "Q627"
+    },
+    {
+      "title": "Nitrogen",
+      "eNumber": "E931",
+      "synonyms": [
+        "E931",
+        "Nitrogen"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Nitrogen oxide",
+      "eNumber": "E932",
+      "synonyms": [
+        "E932",
+        "Nitrogen oxide"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Nitrosyl chloride",
+      "eNumber": "E919",
+      "synonyms": [
+        "E919",
+        "Nitrosyl chloride"
+      ],
+      "functions": [],
+      "description": "Nitrosyl chloride is the chemical compound with the formula NOCl. It is a yellow gas that is most commonly encountered as a decomposition product of aqua regia, a mixture of hydrochloric acid and nitric acid. It is a strong electrophile and oxidizing agent. It is sometimes called Tilden's reagent.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Nitrosyl_chloride",
+      "wikidata": "Q419266"
+    },
+    {
+      "title": "Nitrous oxide",
+      "eNumber": "E942",
+      "synonyms": [
+        "E942",
+        "Nitrous oxide",
+        "propellent gas E942"
+      ],
+      "functions": [
+        "antioxidant",
+        "propellent-gas"
+      ],
+      "description": "Nitrous oxide, commonly known as laughing gas or nitrous, is a chemical compound, an oxide of nitrogen with the formula N2O. At room temperature, it is a colorless non-flammable gas, with a slight metallic scent and taste. At elevated temperatures, nitrous oxide is a powerful oxidizer similar to molecular oxygen. It is insoluble in water at all temperatures. Nitrous oxide has significant medical uses, especially in surgery and dentistry, for its anaesthetic and pain reducing effects. Its name \"laughing gas\", coined by Humphry Davy, is due to the euphoric effects upon inhaling it, a property that has led to its recreational use as a dissociative anaesthetic. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. It also is used as an oxidizer in rocket propellants, and in motor racing to increase the power output of engines. Nitrous oxide occurs in small amounts in the atmosphere, but recently has been found to be a major scavenger of stratospheric ozone, with an impact comparable to that of CFCs. It is estimated that 30% of the N2O in the atmosphere is the result of human activity, chiefly agriculture.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Nitrous_oxide",
+      "wikidata": "Q905750"
+    },
+    {
+      "title": "non-amidated pectines",
+      "eNumber": "E440I",
+      "synonyms": [
+        "E440i",
+        "non-amidated pectines"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Pectin -from Ancient Greek: πηκτικός pēktikós, \"congealed, curdled\"- is a structural heteropolysaccharide contained in the primary cell walls of terrestrial plants. It was first isolated and described in 1825 by Henri Braconnot. It is produced commercially as a white to light brown powder, mainly extracted from citrus fruits, and is used in food as a gelling agent, particularly in jams and jellies. It is also used in dessert fillings, medicines, sweets, as a stabilizer in fruit juices and milk drinks, and as a source of dietary fiber.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pectin",
+      "wikidata": "Q188154"
+    },
+    {
+      "title": "Nucleic acids",
+      "eNumber": "",
+      "synonyms": [
+        "Nucleic acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Oat lecithin",
+      "eNumber": "E322A",
+      "synonyms": [
+        "E322a",
+        "Oat lecithin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "octafluorocyclobutane",
+      "eNumber": "E946",
+      "synonyms": [
+        "E946",
+        "octafluorocyclobutane"
+      ],
+      "functions": [],
+      "description": "Octafluorocyclobutane, or perfluorocyclobutane, C4F8, is an organofluorine compound which enjoys several niche applications. It is related to cyclobutane by replacement of all C–H bonds with C–F bonds. Octafluorocyclobutane is produced by the dimerization of tetrafluoroethylene and the reductive coupling of 1‚2-dichloro-1‚1,2‚2-tetrafluoroethane.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Octafluorocyclobutane",
+      "wikidata": "Q413079"
+    },
+    {
+      "title": "Octyl gallate",
+      "eNumber": "E311",
+      "synonyms": [
+        "E311",
+        "Octyl gallate",
+        "Octyl ester of gallic acid"
+      ],
+      "functions": [],
+      "description": "Octyl gallate is the ester of 1-octanol and gallic acid.  As a food additive, it is used under the E number E311 as an antioxidant and preservative.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Octyl_gallate",
+      "wikidata": "Q2317929"
+    },
+    {
+      "title": "Oligoesters of sucrose type I",
+      "eNumber": "E473A",
+      "synonyms": [
+        "E473a",
+        "Oligoesters of sucrose type I",
+        "Oligoesters of sucrose type II",
+        "Oligoesters of sucrose"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q32418"
+    },
+    {
+      "title": "Orange GGN",
+      "eNumber": "E111",
+      "synonyms": [
+        "E111",
+        "Orange GGN",
+        "Alpha-naphthol",
+        "Alpha-naphtol",
+        "alpha-naphthol orange"
+      ],
+      "functions": [],
+      "description": "Orange GGN, also known as alpha-naphthol orange, is an azo dye formerly used as a food dye. It is the disodium salt of 1--m-sulfophenylazo--2-naphthol-6-sulfonic acid. In Europe, it was denoted by the E Number E111, but has been forbidden for use in foods since 1 January 1978. It has never been included in the food additives list of the Codex Alimentarius.  As such, it is forbidden for food use in general, because toxicological data has shown it is harmful.The absorption spectrum of Orange GGN and Sunset Yellow is nearly identical in visible and ultraviolet range, but they can be distinguished by their IR spectra.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Orange_GGN",
+      "wikidata": "Q929052"
+    },
+    {
+      "title": "Orcein",
+      "eNumber": "E182",
+      "synonyms": [
+        "E182",
+        "Orcein"
+      ],
+      "functions": [],
+      "description": "Orcein, also archil, orchil, lacmus and C.I. Natural Red 28, are names for dyes extracted from several species of lichen, commonly known as \"orchella weeds\", found in various parts of the world. A major source is the archil lichen, Roccella tinctoria. Orcinol is extracted from such lichens. It is then converted to orcein by ammonia and air. In traditional dye-making methods, urine was used as the ammonia source. If the conversion is carried out in the presence of potassium carbonate, calcium hydroxide, and calcium sulfate -in the form of potash, lime, and gypsum in traditional dye-making methods-, the result is litmus, a more complex molecule. The manufacture was described by Cocq in 1812  and in the UK in 1874. Roberts noted orchilla as a principal export of the Cape Verde islands, superior to the same kind of moss found in Italy or the Canaries, that in 1832 was yielding an annual revenue of $200‚000. Commercial archil is either a powder -called cudbear- or a paste. It is red in acidic pH and blue in alkaline pH. Orcein is not approved as a food dye -banned in Europe since January 1977-, with E number E121 before 1977 and E182 after., Its CAS number is 1400-62-0. Its chemical formula is C28H24N2O7. It forms dark brown crystals. It is a mixture of phenoxazone derivates - hydroxyorceins, aminoorceins, and aminoorceinimines. The chemical components of orcein were elucidated only in the 1950s by Hans Musso. The structures are shown below. A paper originally published in 1961, embodying most of Musso's work on components of orcein and litmus, was translated into English and published in 2003 in a special issue of the journal Biotechnic & Histochemistry -Vol 78, No. 6- devoted to the dye.  A single alternative structural formula for orcein, possibly incorrect, is  given by the National Library of Medicine [1] and Emolecules [2]. Orcein is a reddish-brown dye, orchil is a purple-blue dye. Orcein is also used as a stain in microscopy to visualize chromosomes, elastic fibers, Hepatitis B surface antigens, and copper-associated proteins.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Orcein",
+      "wikidata": "Q425645"
+    },
+    {
+      "title": "Organic acids",
+      "eNumber": "",
+      "synonyms": [
+        "Organic acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Orthophenyl phenol",
+      "eNumber": "E231",
+      "synonyms": [
+        "E231",
+        "Orthophenyl phenol",
+        "2-hydroxybiphenyl"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Oxidised polyethylene wax",
+      "eNumber": "E914",
+      "synonyms": [
+        "E914",
+        "Oxidised polyethylene wax"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18608846"
+    },
+    {
+      "title": "Oxidised starch",
+      "eNumber": "E1404",
+      "synonyms": [
+        "E1404",
+        "Oxidised starch"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967259"
+    },
+    {
+      "title": "Oxygen",
+      "eNumber": "E948",
+      "synonyms": [
+        "E948",
+        "Oxygen",
+        "element 8"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q629"
+    },
+    {
+      "title": "Paprika extract",
+      "eNumber": "E160C",
+      "synonyms": [
+        "E160c",
+        "Paprika extract",
+        "capsanthin",
+        "capsorubin",
+        "Paprika oleoresin",
+        "oleoresin of paprika",
+        "oleoresin paprika",
+        "paprika color",
+        "colored with paprika"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Paraffin wax",
+      "eNumber": "E905CII",
+      "synonyms": [
+        "E905cii",
+        "Paraffin wax"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q579764"
+    },
+    {
+      "title": "Partially hydrolyzed lecithin",
+      "eNumber": "E322II",
+      "synonyms": [
+        "E322ii",
+        "Partially hydrolyzed lecithin"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier"
+      ],
+      "description": "Lecithin -UK: , US: , from the Greek lekithos, \"egg yolk\"- is a generic term to designate any group of yellow-brownish fatty substances occurring in animal and plant tissues, which are amphiphilic – they attract both water and fatty substances -and so are both hydrophilic and lipophilic-, and are used for smoothing food textures, dissolving powders -emulsifying-, homogenizing liquid mixtures, and repelling sticking materials.Lecithins are mixtures of glycerophospholipids including phosphatidylcholine, phosphatidylethanolamine, phosphatidylinositol, phosphatidylserine, and phosphatidic acid.Lecithin was first isolated in 1845 by the French chemist and pharmacist Theodore Gobley. In 1850, he named the phosphatidylcholine lécithine. Gobley originally isolated lecithin from egg yolk—λέκιθος lekithos is \"egg yolk\" in Ancient Greek—and established the complete chemical formula of phosphatidylcholine in 1874; in between, he had demonstrated the presence of lecithin in a variety of biological matters, including venous blood, in human lungs, bile, human brain tissue, fish eggs, fish roe, and chicken and sheep brain. Lecithin can easily be extracted chemically using solvents such as hexane, ethanol, acetone, petroleum ether, benzene, etc., or extraction can be done mechanically. It is usually available from sources such as soybeans, eggs, milk, marine sources, rapeseed, cottonseed, and sunflower. It has low solubility in water, but is an excellent emulsifier. In aqueous solution, its phospholipids can form either liposomes, bilayer sheets, micelles, or lamellar structures, depending on hydration and temperature. This results in a type of surfactant that usually is classified as amphipathic. Lecithin is sold as a food additive and dietary supplement. In cooking, it is sometimes used as an emulsifier and to prevent sticking, for example in nonstick cooking spray.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Lecithin",
+      "wikidata": "Q241595"
+    },
+    {
+      "title": "Patent blue v",
+      "eNumber": "E131",
+      "synonyms": [
+        "E131",
+        "Patent blue v",
+        "Food Blue 5",
+        "Sulphan Blue",
+        "Acid Blue 3",
+        "L-Blau 3",
+        "C-Blau 20",
+        "Patentblau V",
+        "Sky Blue",
+        "C.I. 42051"
+      ],
+      "functions": [],
+      "description": "Patent Blue V, also called Food Blue 5, Sulphan Blue, Acid Blue 3, L-Blau 3, C-Blau 20, Patentblau V, Sky Blue, or C.I. 42051 and is a dark bluish synthetic triphenylmethane dye used as a food coloring. As a food additive, it has E number E131. It is a sodium or calcium salt of [4--α--4-diethylaminophenyl--5-hydroxy- 2‚4-disulfophenylmethylidene--2‚5-cyclohexadien-1-ylidene] diethylammonium hydroxide inner salt.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Patent_Blue_V",
+      "wikidata": "Q420087"
+    },
+    {
+      "title": "Pectin",
+      "eNumber": "E440A",
+      "synonyms": [
+        "E440a",
+        "Pectin"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Pectin -from Ancient Greek: πηκτικός pēktikós, \"congealed, curdled\"- is a structural heteropolysaccharide contained in the primary cell walls of terrestrial plants. It was first isolated and described in 1825 by Henri Braconnot. It is produced commercially as a white to light brown powder, mainly extracted from citrus fruits, and is used in food as a gelling agent, particularly in jams and jellies. It is also used in dessert fillings, medicines, sweets, as a stabilizer in fruit juices and milk drinks, and as a source of dietary fiber.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pectin",
+      "wikidata": "Q188154"
+    },
+    {
+      "title": "pectin amide",
+      "eNumber": "E440B",
+      "synonyms": [
+        "E440b",
+        "pectin amide",
+        "amidated pectin"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Pectin -from Ancient Greek: πηκτικός pēktikós, \"congealed, curdled\"- is a structural heteropolysaccharide contained in the primary cell walls of terrestrial plants. It was first isolated and described in 1825 by Henri Braconnot. It is produced commercially as a white to light brown powder, mainly extracted from citrus fruits, and is used in food as a gelling agent, particularly in jams and jellies. It is also used in dessert fillings, medicines, sweets, as a stabilizer in fruit juices and milk drinks, and as a source of dietary fiber.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pectin",
+      "wikidata": "Q188154"
+    },
+    {
+      "title": "Pectins",
+      "eNumber": "E440",
+      "synonyms": [
+        "E440",
+        "Pectins",
+        "pectin"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Pectin -from Ancient Greek: πηκτικός pēktikós, \"congealed, curdled\"- is a structural heteropolysaccharide contained in the primary cell walls of terrestrial plants. It was first isolated and described in 1825 by Henri Braconnot. It is produced commercially as a white to light brown powder, mainly extracted from citrus fruits, and is used in food as a gelling agent, particularly in jams and jellies. It is also used in dessert fillings, medicines, sweets, as a stabilizer in fruit juices and milk drinks, and as a source of dietary fiber.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pectin",
+      "wikidata": "Q188154"
+    },
+    {
+      "title": "Pentapotassium triphosphate",
+      "eNumber": "E451II",
+      "synonyms": [
+        "E451ii",
+        "Pentapotassium triphosphate",
+        "potassium triphosphate",
+        "potassium tripolyphosphate",
+        "KTPP"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium triphosphate -STP-, also  sodium tripolyphosphate -STPP-, or tripolyphosphate -TPP-,- is an inorganic compound with formula Na5P3O10.  It is the sodium salt of the polyphosphate penta-anion, which is the conjugate base of triphosphoric acid.  It is produced on a large scale as a component of many domestic and industrial products, especially detergents.  Environmental problems associated with eutrophication are attributed to its widespread use.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_triphosphate",
+      "wikidata": "Q15632716"
+    },
+    {
+      "title": "Pentasodium triphosphate",
+      "eNumber": "E451I",
+      "synonyms": [
+        "E451i",
+        "Pentasodium triphosphate",
+        "Pentasodium tripolyphosphate",
+        "Sodium triphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium triphosphate -STP-, also  sodium tripolyphosphate -STPP-, or tripolyphosphate -TPP-,- is an inorganic compound with formula Na5P3O10.  It is the sodium salt of the polyphosphate penta-anion, which is the conjugate base of triphosphoric acid.  It is produced on a large scale as a component of many domestic and industrial products, especially detergents.  Environmental problems associated with eutrophication are attributed to its widespread use.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_triphosphate",
+      "wikidata": "Q29145"
+    },
+    {
+      "title": "peptone",
+      "eNumber": "E429",
+      "synonyms": [
+        "E429",
+        "peptone",
+        "tryptone"
+      ],
+      "functions": [],
+      "description": "Tryptone is the assortment of peptides formed by the digestion of casein by the protease trypsin.Tryptone is commonly used in microbiology to produce lysogeny broth for the growth of E. coli and other microorganisms.  It provides a source of amino acids for the growing bacteria. Tryptone is similar to casamino acids, both being digests of casein, but casamino acids can be produced by acid hydrolysis and typically only have free amino acids and few peptide chains. Casamino acids are similar to tryptone, the latter differing by being an incomplete enzymatic hydrolysis with some oligopeptides present, while casamino acids are predominantly free amino acids. Tryptone is also a component of some germination media used in plant propagation.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tryptone",
+      "wikidata": "Q424323"
+    },
+    {
+      "title": "petroleum jelly",
+      "eNumber": "E905B",
+      "synonyms": [
+        "E905b",
+        "petroleum jelly",
+        "petrolatum",
+        "white petrolatum",
+        "soft paraffin",
+        "multi-hydrocarbon"
+      ],
+      "functions": [],
+      "description": "Microcrystalline waxes are a type of wax produced by de-oiling petrolatum, as part of the petroleum refining process. In contrast to the more familiar paraffin wax which contains mostly unbranched alkanes, microcrystalline wax contains a higher percentage of isoparaffinic -branched- hydrocarbons and naphthenic hydrocarbons. It is characterized by the fineness of its crystals in contrast to the larger crystal of paraffin wax. It consists of high molecular weight saturated aliphatic hydrocarbons. It is generally darker, more viscous, denser, tackier and more elastic than paraffin waxes, and has a higher molecular weight and melting point. The elastic and adhesive characteristics of microcrystalline waxes are related to the non-straight chain components which they contain. Typical microcrystalline wax crystal structure is small and thin, making them more flexible than paraffin wax. It is commonly used in cosmetic formulations. Microcrystalline waxes when produced by wax refiners are typically produced to meet a number of ASTM specifications. These include congeal point -ASTM D938-, needle penetration -D1321-, color -ASTM D6045-, and viscosity -ASTM D445-. Microcrystalline waxes can generally be put into two categories: \"laminating\" grades and \"hardening\" grades. The laminating grades typically have a melt point of 140-175 F -60 - 80 oC- and needle penetration of 25 or above. The hardening grades will range from about 175-200 F -80 - 93 oC-, and have a needle penetration of 25 or below. Color in both grades can range from brown to white, depending on the degree of processing done at the refinery level. Microcrystalline waxes are derived from the refining of the heavy distillates from lubricant oil production. This by-product must then be de-oiled at a wax refinery. Depending on the end use and desired specification, the product may then have its odor removed and color removed -which typically starts as a brown or dark yellow-. This is usually done by means of a filtration method or by hydro-treating the wax material.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Microcrystalline_wax",
+      "wikidata": "Q457239"
+    },
+    {
+      "title": "Petroleum wax",
+      "eNumber": "E905C",
+      "synonyms": [
+        "E905c",
+        "Petroleum wax"
+      ],
+      "functions": [],
+      "description": "Microcrystalline waxes are a type of wax produced by de-oiling petrolatum, as part of the petroleum refining process. In contrast to the more familiar paraffin wax which contains mostly unbranched alkanes, microcrystalline wax contains a higher percentage of isoparaffinic -branched- hydrocarbons and naphthenic hydrocarbons. It is characterized by the fineness of its crystals in contrast to the larger crystal of paraffin wax. It consists of high molecular weight saturated aliphatic hydrocarbons. It is generally darker, more viscous, denser, tackier and more elastic than paraffin waxes, and has a higher molecular weight and melting point. The elastic and adhesive characteristics of microcrystalline waxes are related to the non-straight chain components which they contain. Typical microcrystalline wax crystal structure is small and thin, making them more flexible than paraffin wax. It is commonly used in cosmetic formulations. Microcrystalline waxes when produced by wax refiners are typically produced to meet a number of ASTM specifications. These include congeal point -ASTM D938-, needle penetration -D1321-, color -ASTM D6045-, and viscosity -ASTM D445-. Microcrystalline waxes can generally be put into two categories: \"laminating\" grades and \"hardening\" grades. The laminating grades typically have a melt point of 140-175 F -60 - 80 oC- and needle penetration of 25 or above. The hardening grades will range from about 175-200 F -80 - 93 oC-, and have a needle penetration of 25 or below. Color in both grades can range from brown to white, depending on the degree of processing done at the refinery level. Microcrystalline waxes are derived from the refining of the heavy distillates from lubricant oil production. This by-product must then be de-oiled at a wax refinery. Depending on the end use and desired specification, the product may then have its odor removed and color removed -which typically starts as a brown or dark yellow-. This is usually done by means of a filtration method or by hydro-treating the wax material.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Microcrystalline_wax",
+      "wikidata": "Q579764"
+    },
+    {
+      "title": "Phosphated distarch phosphate",
+      "eNumber": "E1413",
+      "synonyms": [
+        "E1413",
+        "Phosphated distarch phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Phosphated distarch phosphate, is a modified resistant starch. It is derived from high amylose maize starch and contains a minimum of 70% dietary fibre. It is currently used as a food additive -E1413- as a freeze-thaw-stable thickener -stabilises the consistency of the foodstuff when frozen and thawed- within the European Union in products such as soups, sauces, frozen gravies and pie fillings.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Phosphated_distarch_phosphate",
+      "wikidata": "Q7187438"
+    },
+    {
+      "title": "Phosphoric acid",
+      "eNumber": "E338",
+      "synonyms": [
+        "E338",
+        "Phosphoric acid",
+        "Orthophosphoric acid",
+        "phosphoricV acid"
+      ],
+      "functions": [
+        "antioxidant",
+        "sequestrant"
+      ],
+      "description": "Phosphoric acid -also known as orthophosphoric acid or phosphoricV acid- is a weak acid with the chemical formula H3PO4. Orthophosphoric acid refers to phosphoric acid, which is the IUPAC name for this compound. The prefix ortho- is used to distinguish the acid from related phosphoric acids, called polyphosphoric acids.  Orthophosphoric acid is a non-toxic acid, which, when pure, is a solid at room temperature and pressure. The conjugate base of phosphoric acid is the dihydrogen phosphate ion, H2PO−4, which in turn has a conjugate base of hydrogen phosphate, HPO2−4, which has a conjugate base of phosphate, PO3−4.  Phosphates are essential for life.The most common source of phosphoric acid is an 85% aqueous solution; such solutions are colourless, odourless, and non-volatile. The 85% solution is a syrupy liquid, but still pourable. Although phosphoric acid does not meet the strict definition of a strong acid, the 85% solution is acidic enough to be corrosive. Because of the high percentage of phosphoric acid in this reagent, at least some of the orthophosphoric acid is condensed into polyphosphoric acids; for the sake of labeling and simplicity, the 85% represents H3PO4 as if it were all in the ortho form. Dilute aqueous solutions of phosphoric acid exist in the ortho form.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Phosphoric_acid",
+      "wikidata": "Q184782"
+    },
+    {
+      "title": "Phytic acid",
+      "eNumber": "E391",
+      "synonyms": [
+        "E391",
+        "Phytic acid"
+      ],
+      "functions": [],
+      "description": "Phytic acid -known as inositol hexakisphosphate -IP6-, inositol polyphosphate, or phytate when in salt form- is the phosphate ester of inositol. It contains six phosphate groups.  At physiological pH, these phosphates are partially ionized.  The resulting anion is a colorless species that has significant nutritional role as the principal storage form of phosphorus in many plant tissues, especially bran and seeds. It can be found in cereals and grains. Catabolites of phytic acid are called lower inositol polyphosphates. Examples are inositol penta- -IP5-, tetra- -IP4-, and triphosphate -IP3-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Phytic_acid",
+      "wikidata": "Q409679"
+    },
+    {
+      "title": "Plain caramel",
+      "eNumber": "E150A",
+      "synonyms": [
+        "E150a",
+        "Plain caramel",
+        "caramel color",
+        "caramel coloring"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Caramel_color",
+      "wikidata": "Q227816"
+    },
+    {
+      "title": "Plant carotenes",
+      "eNumber": "E160AII",
+      "synonyms": [
+        "E160aii",
+        "Plant carotenes"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Polydextrose",
+      "eNumber": "E1200",
+      "synonyms": [
+        "E1200",
+        "Polydextrose",
+        "68424-04-4"
+      ],
+      "functions": [
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Polydextrose is a synthetic polymer of glucose. It is a food ingredient classified as soluble fiber by the U.S. Food and Drug Administration -FDA- as well as Health Canada, as of  April 2013. It is frequently used to increase the dietary fiber content of food, to replace sugar, and to reduce calories and fat content. It is a multi-purpose food ingredient synthesized from dextrose -glucose-, plus about 10 percent sorbitol and 1 percent citric acid. Its E number is E1200. The FDA approved it in 1981. It is 0.1 times as sweet as sugar.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polydextrose",
+      "wikidata": "Q424616"
+    },
+    {
+      "title": "Polyethylene glycol",
+      "eNumber": "E1521",
+      "synonyms": [
+        "E1521",
+        "Polyethylene glycol"
+      ],
+      "functions": [],
+      "description": "Polyethylene glycol -PEG- is a polyether compound with many applications, from industrial manufacturing to medicine. PEG is also known as polyethylene oxide -PEO- or polyoxyethylene -POE-, depending on its molecular weight. The structure of PEG is commonly expressed as H−-O−CH2−CH2-n−OH.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polyethylene_glycol",
+      "wikidata": "Q410083"
+    },
+    {
+      "title": "Polyglycerol esters of fatty acids",
+      "eNumber": "E475",
+      "synonyms": [
+        "E475",
+        "Polyglycerol esters of fatty acids",
+        "Polyglycerol fatty acid esters"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q4037764"
+    },
+    {
+      "title": "Polyglycerol polyricinoleate",
+      "eNumber": "E476",
+      "synonyms": [
+        "E476",
+        "Polyglycerol polyricinoleate",
+        "PGPR"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "Polyglycerol polyricinoleate -PGPR-, E476, is an emulsifier made from glycerol and fatty acids -usually from castor bean, but also from soybean oil-. In chocolate, compound chocolate and similar coatings, PGPR is mainly used with another substance like lecithin to reduce viscosity. It is used at low levels -below 0.5%-, and works by decreasing the friction between the solid particles -e.g. cacao, sugar, milk- in molten chocolate, reducing the yield stress so that it flows more easily, approaching the behaviour of a Newtonian fluid. It can also be used as an emulsifier in spreads and in salad dressings, or to improve the texture of baked goods. It is made up of a short chain of glycerol molecules connected by ether bonds, with ricinoleic acid side chains connected by ester bonds. PGPR is a yellowish, viscous liquid, and is strongly lipophilic: it is soluble in fats and oils and insoluble in water and ethanol.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polyglycerol_polyricinoleate",
+      "wikidata": "Q168686"
+    },
+    {
+      "title": "Polyglycitol syrup",
+      "eNumber": "E964",
+      "synonyms": [
+        "E964",
+        "Polyglycitol syrup"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18601425"
+    },
+    {
+      "title": "Polyoxyethylene (40) stearate",
+      "eNumber": "E431",
+      "synonyms": [
+        "E431",
+        "Polyoxyethylene (40) stearate",
+        "Polyoxyl (40) stearate"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18636149"
+    },
+    {
+      "title": "Polyoxyethylene (8) stearate",
+      "eNumber": "E430",
+      "synonyms": [
+        "E430",
+        "Polyoxyethylene (8) stearate"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Polyoxyethylene sorbitan monolaurate",
+      "eNumber": "E432",
+      "synonyms": [
+        "E432",
+        "Polyoxyethylene sorbitan monolaurate",
+        "Polysorbate 20",
+        "Alkest TW 20",
+        "Tween 20",
+        "PEG(20)sorbitan monolaurate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Polysorbate 20 -common commercial brand names include Scattics, Alkest TW 20 and Tween 20- is a polysorbate-type nonionic surfactant formed by the ethoxylation of sorbitan before the addition of lauric acid. Its stability and relative nontoxicity allows it to be used as a detergent and emulsifier in a number of domestic, scientific, and pharmacological applications. As the name implies the ethoxylation process leaves the molecule with 20 repeat units of polyethylene glycol; in practice these are distributed across 4 different chains leading to a commercial product containing a range of chemical species.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polysorbate_20",
+      "wikidata": "Q413616"
+    },
+    {
+      "title": "Polyoxyethylene sorbitan monooleate",
+      "eNumber": "E433",
+      "synonyms": [
+        "E433",
+        "Polyoxyethylene sorbitan monooleate",
+        "Polysorbate 80"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Polysorbate 80 is a nonionic surfactant and emulsifier often used in foods and cosmetics. This synthetic compound is a viscous, water-soluble yellow liquid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polysorbate_80",
+      "wikidata": "Q420358"
+    },
+    {
+      "title": "Polyoxyethylene sorbitan monopalmitate",
+      "eNumber": "E434",
+      "synonyms": [
+        "E434",
+        "Polyoxyethylene sorbitan monopalmitate",
+        "Polysorbate 40"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q1413823"
+    },
+    {
+      "title": "Polyoxyethylene sorbitan monostearate",
+      "eNumber": "E435",
+      "synonyms": [
+        "E435",
+        "Polyoxyethylene sorbitan monostearate",
+        "Polysorbate 60"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q2103104"
+    },
+    {
+      "title": "Polyoxyethylene sorbitan tristearate",
+      "eNumber": "E436",
+      "synonyms": [
+        "E436",
+        "Polyoxyethylene sorbitan tristearate",
+        "Polysorbate 65"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q2103107"
+    },
+    {
+      "title": "Polyphosphates",
+      "eNumber": "E452",
+      "synonyms": [
+        "E452",
+        "Polyphosphates",
+        "Polyphosphate E452"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q11867365"
+    },
+    {
+      "title": "Polyvinyl alcohol",
+      "eNumber": "E1203",
+      "synonyms": [
+        "E1203",
+        "Polyvinyl alcohol",
+        "Vinyl alcohol polymer",
+        "PVOH",
+        "PVAl"
+      ],
+      "functions": [
+        "thickener"
+      ],
+      "description": "Poly-vinyl alcohol- -PVOH, PVA, or PVAl- is a water-soluble synthetic polymer.  It has the idealized formula [CH2CH-OH-]n.  It is used in papermaking, textiles, and a variety of coatings.  It is white -colourless- and odorless.  It is sometimes supplied as beads or as solutions in water.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polyvinyl_alcohol",
+      "wikidata": "Q146339"
+    },
+    {
+      "title": "Polyvinyl alcohol-polyethylene glycol-graft-co-polymer",
+      "eNumber": "E1209",
+      "synonyms": [
+        "E1209",
+        "Polyvinyl alcohol-polyethylene glycol-graft-co-polymer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Polyvinylpolypyrrolidone",
+      "eNumber": "E1202",
+      "synonyms": [
+        "E1202",
+        "Polyvinylpolypyrrolidone",
+        "Crospovidone",
+        "Cross-linked polyvidone"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "Polyvinylpolypyrrolidone -polyvinyl polypyrrolidone, PVPP, crospovidone, crospolividone or E1202- is a highly cross-linked modification of polyvinylpyrrolidone -PVP-. The cross-linked form of PVP is used as a disintegrant -see also excipients- in pharmaceutical tablets. PVPP is a highly cross-linked version of PVP, making it insoluble in water, though it still absorbs water and swells very rapidly generating a swelling force. This property makes it useful as a disintegrant in tablets. PVPP can be used as a drug, taken as a tablet or suspension to absorb compounds -so-called endotoxins- that cause diarrhoea. -Cf. bone char, charcoal.- It is also used as a fining to extract impurities -via agglomeration followed by filtration-. It is used in winemaking. Using the same principle it is used to remove polyphenols in beer production and thus clear beers with stable foam are produced. One such commercial product is called Polyclar. PVPP forms bonds similar to peptidic bonds in protein -especially, like proline residues- and that is why it can precipitate tannins the same way as proteins do.PVPP has E number code E1202 and is used as a stabiliser.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polyvinylpolypyrrolidone",
+      "wikidata": "Q3003746"
+    },
+    {
+      "title": "Polyvinylpyrrolidone",
+      "eNumber": "E1201",
+      "synonyms": [
+        "E1201",
+        "Polyvinylpyrrolidone",
+        "Povidone",
+        "PVP"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Polyvinylpyrrolidone -PVP-, also commonly called polyvidone or povidone, is a water-soluble polymer made from the monomer N-vinylpyrrolidone:",
+      "wikipedia": "https://en.wikipedia.org/wiki/Polyvinylpyrrolidone",
+      "wikidata": "Q413433"
+    },
+    {
+      "title": "Polyvinylpyrrolidone-vinyl acetate copolymer",
+      "eNumber": "E1208",
+      "synonyms": [
+        "E1208",
+        "Polyvinylpyrrolidone-vinyl acetate copolymer"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Ponceau 4r",
+      "eNumber": "E124",
+      "synonyms": [
+        "E124",
+        "Ponceau 4r",
+        "cochineal red a",
+        "CI Food Red 7",
+        "Brilliant Scarlet 4R",
+        "Ponceau"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Ponceau 4R -known by more than 100 synonyms, including as C.I. 16255, Cochineal Red A, C.I. Acid Red 18, Brilliant Scarlet 3R, Brilliant Scarlet 4R, New Coccine,  is a synthetic colourant that may be used as a food colouring. It is denoted by E Number E124. Its chemical name is 1--4-sulpho-1-napthylazo-- 2-napthol- 6‚8-disulphonic acid, trisodium salt. Ponceau -17th century French for \"poppy-coloured\"- is the generic name for a family of azo dyes. Ponceau 4R is a strawberry red azo dye which can be used in a variety of food products, and is usually synthesized from aromatic hydrocarbons; it is stable to light, heat, and acid but fades in the presence of ascorbic acid.It is used in Europe, Asia and Australia, but has not been approved by the US FDA.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ponceau_4R",
+      "wikidata": "Q384709"
+    },
+    {
+      "title": "Ponceau 6R",
+      "eNumber": "E126",
+      "synonyms": [
+        "E126",
+        "Ponceau 6R"
+      ],
+      "functions": [],
+      "description": "Ponceau 6R, or Crystal ponceau 6R, Crystal scarlet, Brilliant crystal scarlet 6R, Acid Red 44, or C.I. 16250, is a red azo dye. It is soluble in water and slightly soluble in ethanol. It is used as a food dye, with E number E126. It is also used in histology, for staining fibrin with the MSB Trichrome stain. It usually comes as disodium salt. Amaranth is a closely related azo dye, also usable in trichrome staining.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Ponceau_6R",
+      "wikidata": "Q596946"
+    },
+    {
+      "title": "Potassium acetate",
+      "eNumber": "E261",
+      "synonyms": [
+        "E261",
+        "Potassium acetate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Potassium acetate -KCH3COO- is the potassium salt of acetic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_acetate",
+      "wikidata": "Q409199"
+    },
+    {
+      "title": "Potassium adipate",
+      "eNumber": "E357",
+      "synonyms": [
+        "E357",
+        "Potassium adipate"
+      ],
+      "functions": [],
+      "description": "Potassium adipate is a compound with formula K2C6H8O4. It is the potassium salt of adipic acid. It has E number \"E357\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_adipate",
+      "wikidata": "Q931445"
+    },
+    {
+      "title": "Potassium alginate",
+      "eNumber": "E402",
+      "synonyms": [
+        "E402",
+        "Potassium alginate"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q16038950"
+    },
+    {
+      "title": "Potassium aluminium silicate",
+      "eNumber": "E555",
+      "synonyms": [
+        "E555",
+        "Potassium aluminium silicate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18944658"
+    },
+    {
+      "title": "Potassium ascorbate",
+      "eNumber": "E303",
+      "synonyms": [
+        "E303",
+        "Potassium ascorbate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q56410901"
+    },
+    {
+      "title": "Potassium benzoate",
+      "eNumber": "E212",
+      "synonyms": [
+        "E212",
+        "Potassium benzoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Potassium benzoate -E212-, the potassium salt of benzoic acid, is a food preservative that inhibits the growth of mold, yeast and some bacteria. It works best in low-pH products, below 4.5, where it exists as benzoic acid.  Acidic foods and beverages such as fruit juice -citric acid-, sparkling drinks -carbonic acid-, soft drinks -phosphoric acid-, pickles -vinegar-, and frogurt toppings may be preserved with potassium benzoate. It is approved for use in most countries including Canada, the U.S., and the EU, where it is designated by the E number E212. Potassium benzoate is also used in the whistle in many fireworks.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_benzoate",
+      "wikidata": "Q413611"
+    },
+    {
+      "title": "Potassium bisulphite",
+      "eNumber": "E228",
+      "synonyms": [
+        "E228",
+        "Potassium bisulphite",
+        "Potassium bisulfite"
+      ],
+      "functions": [],
+      "description": "Potassium hydrogen sulfite or potassium bisulfite is a chemical compound with the chemical formula KHSO3. It is used during the production of alcoholic beverages as a sterilising agent.  This additive is classified as E number E228 under the current EU approved food additive.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_bisulfite",
+      "wikidata": "Q412524"
+    },
+    {
+      "title": "Potassium bromate",
+      "eNumber": "E924A",
+      "synonyms": [
+        "E924a",
+        "Potassium bromate"
+      ],
+      "functions": [],
+      "description": "Potassium bromate -KBrO3-, is a bromate of potassium and takes the form of white crystals or powder. It is a strong oxidizing agent.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_bromate",
+      "wikidata": "Q409241"
+    },
+    {
+      "title": "Potassium carbonate",
+      "eNumber": "E501I",
+      "synonyms": [
+        "E501i",
+        "Potassium carbonate"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "Potassium carbonate -K2CO3- is a white salt, which is soluble in water -insoluble in ethanol- and forms a strongly alkaline solution. It can be made as the product of potassium hydroxide's absorbent reaction with carbon dioxide. It is deliquescent, often appearing a damp or wet solid. Potassium carbonate is used in the production of soap and glass.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_carbonate",
+      "wikidata": "Q379885"
+    },
+    {
+      "title": "Potassium carbonates",
+      "eNumber": "E501",
+      "synonyms": [
+        "E501",
+        "Potassium carbonates"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "Potassium carbonate -K2CO3- is a white salt, which is soluble in water -insoluble in ethanol- and forms a strongly alkaline solution. It can be made as the product of potassium hydroxide's absorbent reaction with carbon dioxide. It is deliquescent, often appearing a damp or wet solid. Potassium carbonate is used in the production of soap and glass.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_carbonate",
+      "wikidata": "Q379885"
+    },
+    {
+      "title": "Potassium chloride",
+      "eNumber": "E508",
+      "synonyms": [
+        "E508",
+        "Potassium chloride",
+        "Sylvine"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener",
+        "preservative"
+      ],
+      "description": "Potassium chloride -KCl- is a metal halide salt composed of potassium and chlorine. It is odorless and has a white or colorless vitreous crystal appearance. The solid dissolves readily in water and its solutions have a salt-like taste.  KCl is used as a fertilizer, in medicine, in scientific applications, and in food processing.  In a few states of the United States it is used to cause cardiac arrest as the third drug in the \"three drug cocktail\" for executions by lethal injection. It occurs naturally as the mineral sylvite, and in combination with sodium chloride as sylvinite.The version for injection is on the World Health Organization's List of Essential Medicines, the most important medications needed in a basic health system.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_chloride",
+      "wikidata": "Q184630"
+    },
+    {
+      "title": "Potassium citrates",
+      "eNumber": "E332",
+      "synonyms": [
+        "E332",
+        "Potassium citrates"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Potassium citrate -also known as tripotassium citrate- is a potassium salt of citric acid with the molecular formula K3C6H5O7.  It is a white, hygroscopic crystalline powder. It is odorless with a saline taste. It contains 38.28% potassium by mass.  In the monohydrate form it is highly hygroscopic and deliquescent. As a food additive, potassium citrate is used to regulate acidity and is known as E number E332. Medicinally, it may be used to control kidney stones derived from either uric acid or cystine.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_citrate",
+      "wikidata": "Q419921"
+    },
+    {
+      "title": "Potassium ferrocyanide",
+      "eNumber": "E536",
+      "synonyms": [
+        "E536",
+        "Potassium ferrocyanide",
+        "Yellow prussiate of potash"
+      ],
+      "functions": [],
+      "description": "Potassium ferrocyanide is the inorganic compound with formula K4[Fe-CN-6]·3H2O. It is the potassium salt of the coordination complex [Fe-CN-6]4−. This salt forms lemon-yellow monoclinic crystals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_ferrocyanide",
+      "wikidata": "Q422017"
+    },
+    {
+      "title": "Potassium fumarate",
+      "eNumber": "E366",
+      "synonyms": [
+        "E366",
+        "Potassium fumarate"
+      ],
+      "functions": [],
+      "description": "Potassium fumarate is a compound with formula K2C4H2O4. It is the potassium salt of fumaric acid. It has E number \"E366\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_fumarate",
+      "wikidata": "Q723321"
+    },
+    {
+      "title": "Potassium gluconate",
+      "eNumber": "E577",
+      "synonyms": [
+        "E577",
+        "Potassium gluconate"
+      ],
+      "functions": [
+        "sequestrant"
+      ],
+      "description": "Potassium gluconate is the potassium salt of the conjugate base of gluconic acid. It is also referred to as 2‚3,4‚5,6-pentahydroxycaproic acid potassium salt, D-gluconic acid potassium salt, or potassium D-gluconate.It contains 16.69%  potassium by mass. Thus 5.99 g  of potassium gluconate contains 1 g of potassium. It has a density of 1.73 g/cm3.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_gluconate",
+      "wikidata": "Q1122870"
+    },
+    {
+      "title": "Potassium hydrogen carbonate",
+      "eNumber": "E501II",
+      "synonyms": [
+        "E501ii",
+        "Potassium hydrogen carbonate",
+        "Potassium bicarbonate"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "Potassium carbonate -K2CO3- is a white salt, which is soluble in water -insoluble in ethanol- and forms a strongly alkaline solution. It can be made as the product of potassium hydroxide's absorbent reaction with carbon dioxide. It is deliquescent, often appearing a damp or wet solid. Potassium carbonate is used in the production of soap and glass.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_bicarbonate",
+      "wikidata": "Q410529"
+    },
+    {
+      "title": "Potassium hydrogen sulphate",
+      "eNumber": "E515II",
+      "synonyms": [
+        "E515ii",
+        "Potassium hydrogen sulphate",
+        "Potassium bisulphate"
+      ],
+      "functions": [],
+      "description": "Potassium sulfate -K2SO4- -in British English potassium sulphate, also called sulphate of potash, arcanite, or archaically known as potash of sulfur- is a non-flammable white crystalline salt which is soluble in water. The chemical compound is commonly used in fertilizers, providing both potassium and sulfur. When potassium sulfate is heated in water and subjected to swirling in a beaker, the crystals form a multi-arm spiral structure when allowed to settle. Potassium sulfate could be used to study spiral structures in the laboratory.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_sulfate",
+      "wikidata": "Q193054"
+    },
+    {
+      "title": "Potassium hydroxide",
+      "eNumber": "E525",
+      "synonyms": [
+        "E525",
+        "Potassium hydroxide"
+      ],
+      "functions": [],
+      "description": "Potassium hydroxide is an inorganic compound with the formula KOH, and is commonly called caustic potash. Along with sodium hydroxide -NaOH-, this colorless solid is a prototypical strong base. It has many industrial and niche applications, most of which exploit its corrosive nature and its reactivity toward acids. An estimated 700‚000 to 800‚000 tonnes were produced in 2005. About 100 times more NaOH than KOH is produced annually. KOH is noteworthy as the precursor to most soft and liquid soaps, as well as numerous potassium-containing chemicals.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_hydroxide",
+      "wikidata": "Q132298"
+    },
+    {
+      "title": "potassium iodate",
+      "eNumber": "E917",
+      "synonyms": [
+        "E917",
+        "potassium iodate"
+      ],
+      "functions": [],
+      "description": "Potassium iodate -KIO3- is a chemical compound. It is ionic, made up of K+ ions and IO3− ions in a 1:1 ratio.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_iodate",
+      "wikidata": "Q414599"
+    },
+    {
+      "title": "Potassium iodide",
+      "eNumber": "",
+      "synonyms": [
+        "potassium iodide"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_iodide",
+      "wikidata": "Q121874"
+    },
+    {
+      "title": "potassium lactate",
+      "eNumber": "E326",
+      "synonyms": [
+        "E326",
+        "potassium lactate"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier",
+        "humectant"
+      ],
+      "description": "Potassium lactate is a compound with formula KC3H5O3, or H3C-CHOH-COOK. It is the potassium salt of lactic acid. It is produced by neutralizing lactic acid which is fermented from a sugar source.  It has E number \"E326\".  Potassium lactate is a liquid product that is usually 60% solids but is available at up to 78% solids.Potassium lactate is commonly used in meat and poultry products to extend shelf life and increase food safety as it has a broad antimicrobial action and is effective at inhibiting most spoilage and pathogenic bacteria. Potassium lactate is also used as an extinguishing medium in the First Alert Tundra fire extinguishers.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_lactate",
+      "wikidata": "Q411342"
+    },
+    {
+      "title": "Potassium malate",
+      "eNumber": "E351",
+      "synonyms": [
+        "E351",
+        "Potassium malate"
+      ],
+      "functions": [],
+      "description": "Potassium malate is a compound with formula K2-C2H4O-COO-2-. It is the potassium salt of malic acid. As a food additive, it has the E number E351. It is used as acidity regulator or acidifier for use in, for example, canned vegetables, soups, sauces, fruit products and soft drinks. It also acts as an antioxidant and as a food flavor. It is an important compound in the transport of nitrate from the roots of a plant to the leaves of the plant. Potassium malate is the salt that transports from the leaves to the root. At the root the potassium maleate oxidizes to potassium carbonate, then is converted to potassium nitrate by soil nitrate and transported back to the leaves.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_malate",
+      "wikidata": "Q408755"
+    },
+    {
+      "title": "Potassium metabisulphite",
+      "eNumber": "E224",
+      "synonyms": [
+        "E224",
+        "Potassium metabisulphite",
+        "Potassium metabisulfite"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative"
+      ],
+      "description": "Potassium metabisulfite, K2S2O5, also known as potassium pyrosulfite, is a white crystalline powder with a pungent sulfur odour. The main use for the chemical is as an antioxidant or chemical sterilant. It is a disulfite and is chemically very similar to sodium metabisulfite, with which it is sometimes used interchangeably. Potassium metabisulfite is generally preferred out of the two as it does not contribute sodium to the diet. Potassium metabisulfite has a monoclinic crystal structure which decomposes at 190 °C, yielding potassium sulfite and sulfur dioxide:  K2S2O5-s- → K2SO3-s- + SO2-g-",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_metabisulfite",
+      "wikidata": "Q417881"
+    },
+    {
+      "title": "Potassium nitrate",
+      "eNumber": "E252",
+      "synonyms": [
+        "E252",
+        "Potassium nitrate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Potassium nitrate is a chemical compound with the chemical formula KNO3. It is an ionic salt of potassium ions K+ and nitrate ions NO3−, and is therefore an alkali metal nitrate. It occurs in nature as a mineral, niter. It is a source of nitrogen, from which it derives its name. Potassium nitrate is one of several nitrogen-containing compounds collectively referred to as saltpeter or saltpetre. Major uses of potassium nitrate are in fertilizers, tree stump removal, rocket propellants and fireworks. It is one of the major constituents of gunpowder -black powder- and has been used since the Middle Ages as a food preservative.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_nitrate",
+      "wikidata": "Q177836"
+    },
+    {
+      "title": "Potassium nitrite",
+      "eNumber": "E249",
+      "synonyms": [
+        "E249",
+        "Potassium nitrite"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Potassium nitrite -distinct from potassium nitrate- is the inorganic compound with the chemical formula KNO2. It is an ionic salt of potassium ions K+ and nitrite ions NO2−, which forms a white or slightly yellow, hygroscopic crystalline powder that is soluble in water.It is a strong oxidizer and may accelerate the combustion of other materials. Like other nitrite salts such as sodium nitrite, potassium nitrite is toxic if swallowed, and laboratory tests suggest that it may be mutagenic or teratogenic. Gloves and safety glasses are usually used when handling potassium nitrite.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_nitrite",
+      "wikidata": "Q409179"
+    },
+    {
+      "title": "Potassium persulfate",
+      "eNumber": "E922",
+      "synonyms": [
+        "E922",
+        "Potassium persulfate"
+      ],
+      "functions": [],
+      "description": "Not to be confused with potassium peroxymonosulfate.Potassium persulfate is the inorganic compound with the formula K2S2O8. Also known as potassium peroxydisulfate or KPS, it is a white solid that is sparingly soluble in cold water, but dissolves better in warm water. This salt is a powerful oxidant, commonly used to initiate polymerizations.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_persulfate",
+      "wikidata": "Q415226"
+    },
+    {
+      "title": "Potassium phosphates",
+      "eNumber": "E340",
+      "synonyms": [
+        "E340",
+        "Potassium phosphates",
+        "potassium phosphate",
+        "E 340",
+        "E-340"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Potassium phosphate is a generic term for the salts of potassium and phosphate ions including: Monopotassium phosphate -KH2PO4- -Molar mass approx: 136 g/mol- Dipotassium phosphate -K2HPO4- -Molar mass approx: 174 g/mol- Tripotassium phosphate -K3PO4- -Molar mass approx: 212.27 g/mol-As food additives, potassium phosphates have the E number E340.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_phosphate",
+      "wikidata": "Q3381491"
+    },
+    {
+      "title": "Potassium polyphosphate",
+      "eNumber": "E452II",
+      "synonyms": [
+        "E452ii",
+        "Potassium polyphosphate",
+        "Potassium metaphosphate",
+        "Potassium polymetaphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q42807555"
+    },
+    {
+      "title": "Potassium propionate",
+      "eNumber": "E283",
+      "synonyms": [
+        "E283",
+        "Potassium propionate",
+        "Potassium propanoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Potassium propanoate or potassium propionate has formula K-C2H5COO-. Its melting point is 410 °C. It is the potassium salt of propanoic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_propanoate",
+      "wikidata": "Q416435"
+    },
+    {
+      "title": "Potassium silicate",
+      "eNumber": "E560",
+      "synonyms": [
+        "E560",
+        "Potassium silicate"
+      ],
+      "functions": [],
+      "description": "Potassium silicate is the name for a family of inorganic compounds.  The most common potassium silicate has the formula K2SiO3, samples of which contain varying amounts of water.  These are white solids or colorless solutions.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_silicate",
+      "wikidata": "Q419390"
+    },
+    {
+      "title": "Potassium sodium tartrate",
+      "eNumber": "E337",
+      "synonyms": [
+        "E337",
+        "Potassium sodium tartrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Potassium sodium tartrate tetrahydrate, also known as Rochelle salt, is a double salt of tartaric acid first prepared -in about 1675- by an apothecary, Pierre Seignette, of La Rochelle, France. Potassium sodium tartrate and monopotassium phosphate were the first materials discovered to exhibit piezoelectricity. This property led to its extensive use in \"crystal\" gramophone -phono- pick-ups, microphones and earpieces during the post-World War II consumer electronics boom of the mid-20th Century. Such transducers had an exceptionally high output with typical pick-up cartridge outputs as much as 2 volts or more. Rochelle salt is deliquescent so any transducers based on the material deteriorated if stored in damp conditions. It has been used medicinally as a laxative. It has also been used in the process of silvering mirrors. It is an ingredient of Fehling's solution -reagent for reducing sugars-. It is used in electroplating, in electronics and piezoelectricity, and as a combustion accelerator in cigarette paper -similar to an oxidizer in pyrotechnics-.In organic synthesis, it is used in aqueous workups to break up emulsions, particularly for reactions in which an aluminium-based hydride reagent was used. Sodium Potassium tartrate is also important in the food industry. It is a common precipitant in protein crystallography and is also an ingredient in the Biuret reagent which is used to measure protein concentration. This ingredient maintains cupric ions in solution at an alkaline pH.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_sodium_tartrate",
+      "wikidata": "Q303489"
+    },
+    {
+      "title": "Potassium sorbate",
+      "eNumber": "E202",
+      "synonyms": [
+        "E202",
+        "Potassium sorbate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Potassium sorbate is the potassium salt of sorbic acid, chemical formula CH3CH=CH−CH=CH−CO2K.  It is a white salt that is very soluble in water -58.2% at 20 °C-.  It is primarily used as a food preservative -E number 202-. Potassium sorbate is effective in a variety of applications including food, wine, and personal-care products. While sorbic acid is naturally occurring in some berries, virtually all of the world's production of sorbic acid, from which potassium sorbate is derived, is manufactured synthetically.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_sorbate",
+      "wikidata": "Q410744"
+    },
+    {
+      "title": "Potassium sulphate",
+      "eNumber": "E515I",
+      "synonyms": [
+        "E515i",
+        "Potassium sulphate"
+      ],
+      "functions": [],
+      "description": "Potassium sulfate -K2SO4- -in British English potassium sulphate, also called sulphate of potash, arcanite, or archaically known as potash of sulfur- is a non-flammable white crystalline salt which is soluble in water. The chemical compound is commonly used in fertilizers, providing both potassium and sulfur. When potassium sulfate is heated in water and subjected to swirling in a beaker, the crystals form a multi-arm spiral structure when allowed to settle. Potassium sulfate could be used to study spiral structures in the laboratory.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_sulfate",
+      "wikidata": "Q193054"
+    },
+    {
+      "title": "Potassium sulphates",
+      "eNumber": "E515",
+      "synonyms": [
+        "E515",
+        "Potassium sulphates",
+        "Potassium sulfates",
+        "potassium sulfate"
+      ],
+      "functions": [],
+      "description": "Potassium sulfate -K2SO4- -in British English potassium sulphate, also called sulphate of potash, arcanite, or archaically known as potash of sulfur- is a non-flammable white crystalline salt which is soluble in water. The chemical compound is commonly used in fertilizers, providing both potassium and sulfur. When potassium sulfate is heated in water and subjected to swirling in a beaker, the crystals form a multi-arm spiral structure when allowed to settle. Potassium sulfate could be used to study spiral structures in the laboratory.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_sulfate",
+      "wikidata": "Q193054"
+    },
+    {
+      "title": "Potassium tartrates",
+      "eNumber": "E336",
+      "synonyms": [
+        "E336",
+        "Potassium tartrates"
+      ],
+      "functions": [],
+      "description": "Potassium tartrate, dipotassium tartrate or argol has formula K2C4H4O6. It is the potassium salt of tartaric acid.  It is often confused with potassium bitartrate, also known as cream of tartar.  As a food additive, it shares the E number E336 with potassium bitartrate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_tartrate",
+      "wikidata": "Q65770886"
+    },
+    {
+      "title": "Powdered cellulose",
+      "eNumber": "E460II",
+      "synonyms": [
+        "E460ii",
+        "Powdered cellulose",
+        "Purified cellulose"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Cellulose is an organic compound with the formula -C6H10O5-n, a polysaccharide consisting of a linear chain of several hundred to many thousands of β-1→4- linked D-glucose units. Cellulose is an important structural component of the primary cell wall of green plants, many forms of algae and the oomycetes. Some species of bacteria secrete it to form biofilms. Cellulose is the most abundant organic polymer on Earth.  The cellulose content of cotton fiber is 90%, that of wood is 40–50%, and that of dried hemp is approximately 57%.Cellulose is mainly used to produce paperboard and paper. Smaller quantities are converted into a wide variety of derivative products such as cellophane and rayon. Conversion of cellulose from energy crops into biofuels such as cellulosic ethanol is under development as a renewable fuel source. Cellulose for industrial use is mainly obtained from wood pulp and cotton.Some animals, particularly ruminants and termites, can digest cellulose with the help of symbiotic micro-organisms that live in their guts, such as Trichonympha. In human nutrition, cellulose is a non-digestible constituent of insoluble dietary fiber, acting as a hydrophilic bulking agent for feces and potentially aiding in defecation.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Cellulose",
+      "wikidata": "Q80294"
+    },
+    {
+      "title": "Processed eucheuma seaweed",
+      "eNumber": "E407A",
+      "synonyms": [
+        "E407a",
+        "Processed eucheuma seaweed"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Carrageenans or carrageenins - karr-ə-gee-nənz, from Irish carraigín, \"little rock\"- are a family of linear sulfated polysaccharides that are extracted from red edible seaweeds. They are widely used in the food industry, for their gelling, thickening, and stabilizing properties. Their main application is in dairy and meat products, due to their strong binding to food proteins. There are three main varieties of carrageenan, which differ in their degree of sulfation. Kappa-carrageenan has one sulfate group per disaccharide, iota-carrageenan has two, and lambda-carrageenan has three. Gelatinous extracts of the Chondrus crispus -Irish moss- seaweed have been used as food additives since approximately the fifteenth century. Carrageenan is a vegetarian and vegan alternative to gelatin in some applications or may be used to replace gelatin in confectionery.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carrageenan",
+      "wikidata": "Q421991"
+    },
+    {
+      "title": "Propane",
+      "eNumber": "E944",
+      "synonyms": [
+        "E944",
+        "Propane"
+      ],
+      "functions": [],
+      "description": "Propane -- is a three-carbon alkane with the molecular formula C3H8. It is a gas at standard temperature and pressure, but compressible to a transportable liquid. A by-product of natural gas processing and petroleum refining, it is commonly used as a fuel. Propane is one of a group of liquefied petroleum gases -LP gases-. The others include butane, propylene, butadiene, butylene, isobutylene, and mixtures thereof.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Propane",
+      "wikidata": "Q131189"
+    },
+    {
+      "title": "Propane-1‚2-diol alginate",
+      "eNumber": "E405",
+      "synonyms": [
+        "E405",
+        "Propane-1‚2-diol alginate",
+        "Propylene glycol alginate"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Propylene glycol alginate -PGA- is an  emulsifier,  stabilizer, and  thickener used in food products. It is a food additive with E number E405.  Chemically, propylene glycol alginate is an ester of alginic acid, which is derived from kelp.   Some of the carboxyl groups are esterified with propylene glycol, some are neutralized with an appropriate alkali, and some remain free.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Propylene_glycol_alginate",
+      "wikidata": "Q2474785"
+    },
+    {
+      "title": "Propane-1‚2-diol esters of fatty acids",
+      "eNumber": "E477",
+      "synonyms": [
+        "E477",
+        "Propane-1‚2-diol esters of fatty acids"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18944660"
+    },
+    {
+      "title": "Propionic acid",
+      "eNumber": "E280",
+      "synonyms": [
+        "E280",
+        "Propionic acid",
+        "Propanoic acid",
+        "CH3CH2COOH"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Propionic acid -from the Greek words protos, meaning \"first\", and pion, meaning \"fat\"; also known as propanoic acid- is a naturally occurring carboxylic acid with chemical formula CH3CH2CO2H.  It is a liquid with a pungent and unpleasant smell somewhat resembling body odor. The anion CH3CH2CO2− as well as the salts and esters of propionic acid are known as propionates -or propanoates-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Propionic_acid",
+      "wikidata": "Q422956"
+    },
+    {
+      "title": "Propyl gallate",
+      "eNumber": "E310",
+      "synonyms": [
+        "E310",
+        "Propyl gallate",
+        "Propyl ester of gallic acid"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Propyl gallate, or propyl 3‚4,5-trihydroxybenzoate is an ester formed by the condensation of gallic acid and propanol.  Since 1948, this antioxidant has been added to foods containing oils and fats to prevent oxidation.  As a food additive, it is used under the E number E310.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Propyl_gallate",
+      "wikidata": "Q608726"
+    },
+    {
+      "title": "Propyl para-hydroxybenzoate",
+      "eNumber": "E216",
+      "synonyms": [
+        "E216",
+        "Propyl para-hydroxybenzoate",
+        "Sodium Salt of Propyl-p-hydroxy Benzoic Acid",
+        "Propylparaben"
+      ],
+      "functions": [],
+      "description": "Propylparaben, the n-propyl ester of p-hydroxybenzoic acid, occurs as a natural substance found in many plants and some insects, although it is manufactured synthetically for use in cosmetics, pharmaceuticals and foods. It is a preservative typically found in many water-based cosmetics, such as creams, lotions, shampoos and bath products.  As a food additive, it has the E number E216. Sodium propyl p-hydroxybenzoate, the sodium salt of propylparaben, a compound with formula Na-C3H7-C6H4COO-O-, is also used similarly as a food additive and as an anti-fungal preservation agent. Its E number is E217. In 2010 the European Union Scientific Committee on Consumer Safety stated that it considered the use of  butylparaben and propylparaben as preservatives in finished cosmetic products as safe to the consumer, as long as the sum of their individual concentrations does not exceed 0.19%.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Propylparaben",
+      "wikidata": "Q511627"
+    },
+    {
+      "title": "Propylene glycol",
+      "eNumber": "E490",
+      "synonyms": [
+        "E490",
+        "Propylene glycol",
+        "1‚2-propanediol",
+        "propane-1‚2-diol",
+        "1‚2-dihydroxypropane",
+        "α-propylene glycol",
+        "methyl ethyl glycol",
+        "methylethylene glycol",
+        "Propan-1‚2-diol"
+      ],
+      "functions": [],
+      "description": "Propylene glycol -IUPAC name: propane-1‚2-diol- is a synthetic organic compound with the chemical formula C3H8O2. It is a viscous, colorless liquid which is nearly odorless but possesses a faintly sweet taste. Chemically it is classed as a diol and is miscible with a broad range of solvents, including water, acetone, and chloroform. It is produced on a large scale and is primarily used in the production of polymers, but also sees use in food processing, and as a process fluid in low-temperature heat-exchange applications.  In the European Union, it has the E-number E1520 for food applications. For cosmetics and pharmacology, the number is E490. Propylene glycol is also present in propylene glycol alginate which known as E405. The compound is sometimes called -alpha- α-propylene glycol to distinguish it from the isomer propane-1‚3-diol, known as -beta- β-propylene glycol.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Propylene_glycol",
+      "wikidata": "Q161495"
+    },
+    {
+      "title": "Propylene Glycol",
+      "eNumber": "E1520",
+      "synonyms": [
+        "E1520",
+        "Propylene Glycol",
+        "Propane-1‚2-diol",
+        "Propan-1‚2-diol"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967269"
+    },
+    {
+      "title": "Protease",
+      "eNumber": "E1101",
+      "synonyms": [
+        "E1101",
+        "Protease",
+        "peptidase",
+        "proteinase",
+        "EC 3.4",
+        "E-1101",
+        "E 1101"
+      ],
+      "functions": [
+        "stabiliser"
+      ],
+      "description": "A protease -also called a peptidase or proteinase- is an enzyme that performs proteolysis: protein catabolism by hydrolysis of peptide bonds. Proteases have evolved multiple times, and different classes of protease can perform the same reaction by completely different catalytic mechanisms. Proteases can be found in Animalia, Plantae, Fungi, Bacteria, Archaea and viruses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Protease",
+      "wikidata": "Q212410"
+    },
+    {
+      "title": "Pullulan",
+      "eNumber": "E1204",
+      "synonyms": [
+        "E1204",
+        "Pullulan",
+        "Linear"
+      ],
+      "functions": [
+        "thickener"
+      ],
+      "description": "Pullulan is a polysaccharide polymer consisting of maltotriose units, also known as α-1‚4- ;α-1‚6-glucan'.  Three glucose units in maltotriose are connected by an α-1‚4 glycosidic bond, whereas consecutive maltotriose units are connected to each other by an α-1‚6 glycosidic bond. Pullulan is produced from starch by the fungus Aureobasidium pullulans. Pullulan is mainly used by the cell to resist desiccation and predation. The presence of this polysaccharide also facilitates diffusion of molecules both into and out of the cell.As an edible, mostly tasteless polymer, the chief commercial use of pullulan is in the manufacture of edible films that are used in various breath freshener or oral hygiene products such as Listerine Cool Mint of Johnson and Johnson -USA- and Meltz Super Thin Mints of Avery Bio-Tech Private Ltd. -India-. As a food additive, it is known by the E number E1204.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Pullulan",
+      "wikidata": "Q419779"
+    },
+    {
+      "title": "Quellkohlensäure",
+      "eNumber": "",
+      "synonyms": [],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Quillaia extract",
+      "eNumber": "E999",
+      "synonyms": [
+        "E999",
+        "Quillaia extract",
+        "Soapbark extract",
+        "Quillay bark extract",
+        "Panama bark extract",
+        "Quillai extract",
+        "Murillo bark extract",
+        "Quillaia"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "Quillaia is the milled inner bark or small stems and branches of the soapbark -Quillaja saponaria, Molina-. Other names include Murillo bark extract, Panama bark extract, Vanilla extract, Quillaia extract, Quillay bark extract, and Soapbark extract. It contains a high concentration of saponins which is increased by processing; highly purified quillaia is used to enhance vaccines. Other compounds in the extract include tannins and other polyphenols, and calcium oxalate. It is listed as an ingredient in root beer and cream soda. The extract of quillaia is used in the manufacture of food additives -E number 999-. It is used as a humectant in baked goods, frozen dairy products, and puddings and as a foaming agent in soft drinks. It is also applied in some \"natural\" spray adjuvant formulations for agriculture. In particular, the saponins from Quillaja saponaria are used in veterinary vaccines as adjuvant -e.g., foot-and-mouth disease vaccines, helping to enhance the immune response-. Initially the crude fraction was used. Later on, a purified mixture called Quil A was developed by Dalsgaard, which was more effective and caused fewer local side reactions. Quil A is still a mixture of more than 25 different saponin molecules. One of them, the saponin QS21, is being investigated for possible beneficial adjuvant effects on the human immune system.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Quillaia",
+      "wikidata": "Q118843"
+    },
+    {
+      "title": "Quinoline yellow",
+      "eNumber": "E104",
+      "synonyms": [
+        "E104",
+        "Quinoline yellow",
+        "Quinoline Yellow WS",
+        "C.I. 47005",
+        "Food Yellow 13"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Quinoline Yellow WS is a mixture of organic compounds derived from the dye Quinoline Yellow SS -Spirit Soluble-.  Owing to the presence of sulfonate groups, the WS dyes are water-soluble -WS-.  It is a mixture of disulfonates -principally-, monosulfonates and trisulfonates of 2--2-quinolyl-indan-1‚3-dione with a maximum absorption wavelength of 416 nm.p. 119",
+      "wikipedia": "https://en.wikipedia.org/wiki/Quinoline_Yellow_WS",
+      "wikidata": "Q420123"
+    },
+    {
+      "title": "Red 2G",
+      "eNumber": "E128",
+      "synonyms": [
+        "E128",
+        "Red 2G"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Red 2G is a synthetic red azo dye. It is soluble in water and slightly soluble in glycerol. It usually comes as a disodium salt of 8-acetamido-1-hydroxy-2-phenylazonaphthalene-3‚6 disulfonate.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Red_2G",
+      "wikidata": "Q417819"
+    },
+    {
+      "title": "Red iron oxide",
+      "eNumber": "E172II",
+      "synonyms": [
+        "E172ii",
+        "Red iron oxide",
+        "iron(III) oxide",
+        "ferric oxide"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q3045754"
+    },
+    {
+      "title": "Riboflavin",
+      "eNumber": "E101",
+      "synonyms": [
+        "E101",
+        "Riboflavin",
+        "Vitamin B2",
+        "Flavaxin",
+        "Vitamin B 2",
+        "Vitamin G",
+        "Riboflavine",
+        "Lactoflavine",
+        "Lactoflavin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement. Food sources include eggs, green vegetables, milk and other dairy product, meat, mushrooms, and almonds. Some countries require its addition to grains. As a supplement it is used to prevent and treat riboflavin deficiency and prevent migraines. It may be given by mouth or injection.It is nearly always well tolerated. Normal doses are safe during pregnancy. Riboflavin is in the vitamin B group. It is required by the body for cellular respiration.Riboflavin was discovered in 1920, isolated in 1933, and first made in 1935. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. Riboflavin is available as a generic medication and over the counter. In the United States a month of supplements costs less than 25 USD.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Riboflavin",
+      "wikidata": "Q130365"
+    },
+    {
+      "title": "Riboflavin",
+      "eNumber": "E101I",
+      "synonyms": [
+        "E101i",
+        "Riboflavin",
+        "Vitamin B2"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement. Food sources include eggs, green vegetables, milk and other dairy product, meat, mushrooms, and almonds. Some countries require its addition to grains. As a supplement it is used to prevent and treat riboflavin deficiency and prevent migraines. It may be given by mouth or injection.It is nearly always well tolerated. Normal doses are safe during pregnancy. Riboflavin is in the vitamin B group. It is required by the body for cellular respiration.Riboflavin was discovered in 1920, isolated in 1933, and first made in 1935. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. Riboflavin is available as a generic medication and over the counter. In the United States a month of supplements costs less than 25 USD.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Riboflavin",
+      "wikidata": "Q130365"
+    },
+    {
+      "title": "Riboflavin-5′-phosphate",
+      "eNumber": "E101II",
+      "synonyms": [
+        "E101ii",
+        "Riboflavin-5′-phosphate",
+        "phosphate lactoflavina"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Riboflavin, also known as vitamin B2, is a vitamin found in food and used as a dietary supplement. Food sources include eggs, green vegetables, milk and other dairy product, meat, mushrooms, and almonds. Some countries require its addition to grains. As a supplement it is used to prevent and treat riboflavin deficiency and prevent migraines. It may be given by mouth or injection.It is nearly always well tolerated. Normal doses are safe during pregnancy. Riboflavin is in the vitamin B group. It is required by the body for cellular respiration.Riboflavin was discovered in 1920, isolated in 1933, and first made in 1935. It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system. Riboflavin is available as a generic medication and over the counter. In the United States a month of supplements costs less than 25 USD.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Riboflavin",
+      "wikidata": "Q130365"
+    },
+    {
+      "title": "Rice bran wax",
+      "eNumber": "E908",
+      "synonyms": [
+        "E908",
+        "Rice bran wax"
+      ],
+      "functions": [],
+      "description": "Rice bran wax is the vegetable wax extracted from the bran oil of rice -Oryza sativa-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Rice_bran_wax",
+      "wikidata": "Q725234"
+    },
+    {
+      "title": "saccharin and its salts",
+      "eNumber": "E954",
+      "synonyms": [
+        "E954",
+        "saccharin and its salts",
+        "saccharin",
+        "saccharin sodium salt",
+        "saccharin sodium",
+        "sodium saccharin salt",
+        "saccharin calcium salt",
+        "saccharin calcium",
+        "calcium saccharine",
+        "saccharin potassium salt",
+        "saccharine potassium",
+        "potassium saccharine",
+        "sodium saccharin"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Sodium saccharin -benzoic sulfimide- is an artificial sweetener with effectively no food energy. It is about 300–400 times as sweet as sucrose but has a bitter or metallic aftertaste, especially at high concentrations.  Saccharin is used to sweeten products such as drinks, candies, cookies, and medicines.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Saccharin",
+      "wikidata": "Q191381"
+    },
+    {
+      "title": "saffron",
+      "eNumber": "E164",
+      "synonyms": [
+        "E164",
+        "saffron",
+        "Gardenia Yellow"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Saffron",
+      "wikidata": "Q25434"
+    },
+    {
+      "title": "Salt of aspartame-acesulfame",
+      "eNumber": "E962",
+      "synonyms": [
+        "E962",
+        "Salt of aspartame-acesulfame",
+        "Aspartame-acesulfame",
+        "Aspartame-acesulfame salt",
+        "E-962",
+        "E 962"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Aspartame-acesulfame salt is an artificial sweetener marketed under the name Twinsweet. It is produced by soaking a 2-1 mixture of aspartame and acesulfame potassium in an acidic solution and allowing it to crystallize; moisture and potassium are removed during this process. It is approximately 350 times as sweet as sucrose. It has been given the E number E962.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Aspartame-acesulfame_salt",
+      "wikidata": "Q409847"
+    },
+    {
+      "title": "Sandalwood",
+      "eNumber": "E166",
+      "synonyms": [
+        "E166",
+        "Sandalwood"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Scarlet GN",
+      "eNumber": "E125",
+      "synonyms": [
+        "E125",
+        "Scarlet GN",
+        "C.I. Food Red 1",
+        "Ponceau SX",
+        "FD&C Red No. 4",
+        "C.I. 14700"
+      ],
+      "functions": [],
+      "description": "Scarlet GN, or C.I. Food Red 1, Ponceau SX, FD&C Red No. 4, or C.I. 14700 is a red azo dye once used as a food dye. As a food additive, it has the E number E125. It usually used as a disodium salt. In the United States, it is not permitted for use in food or ingested drugs and may only be used in externally applied drugs and cosmetics. An exception was added in 1965 to allow the coloring of maraschino cherries, which then were considered mainly decorative and not a foodstuff. This exception was repealed in 1976 due to mounting evidence over its safety concerns. In the European Union, it is not permitted as a food additive.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Scarlet_GN",
+      "wikidata": "Q934310"
+    },
+    {
+      "title": "Shellac",
+      "eNumber": "E904",
+      "synonyms": [
+        "E904",
+        "Shellac",
+        "Bleached shellac"
+      ],
+      "functions": [],
+      "description": "Shellac is a resin secreted by the female lac bug, on trees in the forests of India and Thailand. It is processed and sold as dry flakes -pictured- and dissolved in alcohol to make liquid shellac, which is used as a brush-on colorant, food glaze and wood finish. Shellac functions as a tough natural primer, sanding sealant, tannin-blocker, odour-blocker, stain, and high-gloss varnish. Shellac was once used in electrical applications as it possesses good insulation qualities and it seals out moisture. Phonograph and 78 rpm gramophone records were made of it until they were replaced by vinyl long-playing records from the 1950s onwards. From the time it replaced oil and wax finishes in the 19th century, shellac was one of the dominant wood finishes in the western world until it was largely replaced by nitrocellulose lacquer in the 1920s and 1930s.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Shellac",
+      "wikidata": "Q429659"
+    },
+    {
+      "title": "Silicon dioxide",
+      "eNumber": "E551",
+      "synonyms": [
+        "E551",
+        "Silicon dioxide",
+        "Silica",
+        "SiO2"
+      ],
+      "functions": [
+        "carrier"
+      ],
+      "description": "Silicon dioxide, also known as silica, silicic acid or silicic acid anydride is an oxide of silicon with the chemical formula SiO2, most commonly found in nature as quartz and in various living organisms. In many parts of the world, silica is the major constituent of sand. Silica is one of the most complex and most abundant families of materials, existing as a compound of several minerals and as synthetic product. Notable examples include fused quartz, fumed silica, silica gel, and aerogels. It is used in structural materials, microelectronics -as an electrical insulator-, and as components in the food and pharmaceutical industries. Inhaling finely divided crystalline silica is toxic  and can lead to severe inflammation of the lung tissue, silicosis, bronchitis, lung cancer, and systemic autoimmune diseases, such as lupus and rheumatoid arthritis. Uptake of amorphous silicon dioxide, in high doses, leads to non-permanent short-term inflammation, where all effects heal.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Silicon_dioxide",
+      "wikidata": "Q116269"
+    },
+    {
+      "title": "Silver",
+      "eNumber": "E174",
+      "synonyms": [
+        "E174",
+        "Silver",
+        "element 47"
+      ],
+      "functions": [],
+      "description": "Silver is a chemical element with symbol Ag -from the Latin argentum, derived from the Proto-Indo-European h₂erǵ: \"shiny\" or \"white\"- and atomic number 47. A soft, white, lustrous transition metal, it exhibits the highest electrical conductivity, thermal conductivity, and reflectivity of any metal. The metal is found in the Earth's crust in the pure, free elemental form -\"native silver\"-, as an alloy with gold and other metals, and in minerals such as argentite and chlorargyrite. Most silver is produced as a byproduct of copper, gold, lead, and zinc refining. Silver has long been valued as a precious metal. Silver metal is used in many bullion coins, sometimes alongside gold: while it is more abundant than gold, it is much less abundant as a native metal. Its purity is typically measured on a per-mille basis; a 94%-pure alloy is described as \"0.940 fine\". As one of the seven metals of antiquity, silver has had an enduring role in most human cultures. Other than in currency and as an investment medium -coins and bullion-, silver is used in solar panels, water filtration, jewellery, ornaments, high-value tableware and utensils -hence the term silverware-, in electrical contacts and conductors, in specialized mirrors, window coatings, in catalysis of chemical reactions, as a colorant in stained glass and in specialised confectionery. Its compounds are used in photographic and X-ray film. Dilute solutions of silver nitrate and other silver compounds are used as disinfectants and microbiocides -oligodynamic effect-, added to bandages and wound-dressings, catheters, and other medical instruments.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Silver",
+      "wikidata": "Q1090"
+    },
+    {
+      "title": "Sodium acetate",
+      "eNumber": "E262I",
+      "synonyms": [
+        "E262i",
+        "Sodium acetate"
+      ],
+      "functions": [
+        "preservative",
+        "sequestrant"
+      ],
+      "description": "Sodium acetate, CH3COONa, also abbreviated NaOAc, is the sodium salt of acetic acid. This colorless deliquescent salt has a wide range of uses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_acetate",
+      "wikidata": "Q339940"
+    },
+    {
+      "title": "Sodium acetates",
+      "eNumber": "E262",
+      "synonyms": [
+        "E262",
+        "Sodium acetates"
+      ],
+      "functions": [
+        "preservative",
+        "sequestrant"
+      ],
+      "description": "Sodium acetate, CH3COONa, also abbreviated NaOAc, is the sodium salt of acetic acid. This colorless deliquescent salt has a wide range of uses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_acetate",
+      "wikidata": "Q339940"
+    },
+    {
+      "title": "Sodium adipate",
+      "eNumber": "E356",
+      "synonyms": [
+        "E356",
+        "Sodium adipate"
+      ],
+      "functions": [],
+      "description": "Sodium adipate is a compound with formula Na2C6H8O4. It is the sodium salt of adipic acid. It has E number \"E356\".",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_adipate",
+      "wikidata": "Q423296"
+    },
+    {
+      "title": "sodium alginate",
+      "eNumber": "E401",
+      "synonyms": [
+        "E401",
+        "sodium alginate"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q1187513"
+    },
+    {
+      "title": "Sodium aluminium phosphate",
+      "eNumber": "E541",
+      "synonyms": [
+        "E541",
+        "Sodium aluminium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium aluminium phosphate -SAlP- describes the inorganic compounds consisting of sodium salts of aluminium phosphates.  The most common SAlP has the formulas NaH14Al3-PO4-8·4H2O and Na3H15Al2-PO4-8. These materials are prepared by combining alumina, phosphoric acid, and sodium hydroxide.In addition to the usual hydrate, an anhydrous SAlP is also known, Na3H15Al2-PO4-8 -CAS#10279-59-1-, referred to as 8:2:3, reflecting the ratio of phosphate to aluminium to sodium.  Additionally an SAlP of ill-defined stoichiometry is used -NaxAly-PO4-z -CAS# 7785-88-8-.The acidic sodium aluminium phosphates are used as acids for baking powders for the chemical leavening of baked goods. Upon heating, SAlP combines with the baking soda to give carbon dioxide.  Most of its action occurs at baking temperatures, rather than when the dough or batter is mixed at room temperature.  SAlPs are advantageous because they impart a neutral flavor.   As a food additive, it has the E number E541.  Basic sodium aluminium phosphates are also known, e.g., Na15Al3-PO4-8.  These species are useful in cheese making.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_aluminium_phosphate",
+      "wikidata": "Q1220360"
+    },
+    {
+      "title": "Sodium aluminium silicate",
+      "eNumber": "E554",
+      "synonyms": [
+        "E554",
+        "Sodium aluminium silicate",
+        "Sodium silicoaluminate",
+        "Sodium aluminosilicate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967277"
+    },
+    {
+      "title": "Sodium ascorbate",
+      "eNumber": "E301",
+      "synonyms": [
+        "E301",
+        "Sodium ascorbate",
+        "Sodium L-ascorbate"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Sodium ascorbate is one of a number of mineral salts of ascorbic acid -vitamin C-. The molecular formula of this chemical compound is C6H7NaO6. As the sodium salt of ascorbic acid, it is known as a mineral ascorbate. It has not been demonstrated to be more bioavailable than any other form of vitamin C supplement.Sodium ascorbate normally provides 131 mg of sodium per 1‚000 mg of ascorbic acid -1‚000 mg of sodium ascorbate contains 889 mg of ascorbic acid and 111 mg of sodium-. As a food additive, it has the E number E301 and is used as an antioxidant and an acidity regulator. It is approved for use as a food additive in the EU, USA, and Australia and New Zealand.In in vitro studies, sodium ascorbate has been found to produce cytotoxic effects in various malignant cell lines, which include melanoma cells that are particularly susceptible.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_ascorbate",
+      "wikidata": "Q424551"
+    },
+    {
+      "title": "Sodium benzoate",
+      "eNumber": "E211",
+      "synonyms": [
+        "E211",
+        "Sodium benzoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sodium benzoate is a substance which has the chemical formula NaC7H5O2. It is a widely used food preservative, with an E number of E211. It is the sodium salt of benzoic acid and exists in this form when dissolved in water. It can be produced by reacting sodium hydroxide with benzoic acid.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_benzoate",
+      "wikidata": "Q423971"
+    },
+    {
+      "title": "Sodium bisulphite",
+      "eNumber": "E222",
+      "synonyms": [
+        "E222",
+        "Sodium bisulphite",
+        "Sodium bisulfite"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative"
+      ],
+      "description": "Sodium bisulfite -or sodium bisulphite- -sodium hydrogen sulfite- is a chemical compound with the chemical formula NaHSO3. Sodium bisulfite is a food additive with E number E222. This salt of bisulfite can be prepared by bubbling sulfur dioxide in a solution of sodium carbonate in water. Sodium bisulfite in contact with chlorine bleach -aqueous solution of sodium hypochlorite- will generate heat and form sodium bisulfate and sodium chloride.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_bisulfite",
+      "wikidata": "Q407891"
+    },
+    {
+      "title": "Sodium calcium polyphosphate",
+      "eNumber": "E452III",
+      "synonyms": [
+        "E452iii",
+        "Sodium calcium polyphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967198"
+    },
+    {
+      "title": "Sodium carbonate",
+      "eNumber": "E500I",
+      "synonyms": [
+        "E500i",
+        "Sodium carbonate",
+        "washing soda"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium carbonate, Na2CO3, -also known as washing soda, soda ash and soda crystals, and in the monohydrate form as crystal carbonate- is the water-soluble sodium salt of carbonic acid. It most commonly occurs as a crystalline decahydrate, which readily effloresces to form a white powder, the monohydrate. Pure sodium carbonate is a white, odorless powder that is hygroscopic -absorbs moisture from the air-. It has a strongly alkaline taste, and forms a moderately basic solution in water. Sodium carbonate is well known domestically for its everyday use as a water softener. Historically it was extracted from the ashes of plants growing in sodium-rich soils, such as vegetation from the Middle East, kelp from Scotland and seaweed from Spain. Because the ashes of these sodium-rich plants were noticeably different from ashes of timber -used to create potash-, they became known as \"soda ash\". It is synthetically produced in large quantities from salt -sodium chloride- and limestone by a method known as the Solvay process. The manufacture of glass is one of the most important uses of sodium carbonate. Sodium carbonate acts as a flux for silica, lowering the melting point of the mixture to something achievable without special materials. This \"soda glass\" is mildly water-soluble, so some calcium carbonate is added to the melt mixture to make the glass produced insoluble. This type of glass is known as soda lime glass: \"soda\" for the sodium carbonate and \"lime\" for the calcium carbonate. Soda lime glass has been the most common form of glass for centuries. Sodium carbonate is also used as a relatively strong base in various settings. For example, it is used as a pH regulator to maintain stable alkaline conditions necessary for the action of the majority of photographic film developing agents. It acts as an alkali because when dissolved in water, it dissociates into the weak acid: carbonic acid and the strong alkali: sodium hydroxide. This gives sodium carbonate in solution the ability to attack metals such as aluminium with the release of hydrogen gas.It is a common additive in swimming pools used to raise the pH which can be lowered by chlorine tablets and other additives which contain acids. In cooking, it is sometimes used in place of sodium hydroxide for lyeing, especially with German pretzels and lye rolls. These dishes are treated with a solution of an alkaline substance to change the pH of the surface of the food and improve browning. In taxidermy, sodium carbonate added to boiling water will remove flesh from the bones of animal carcasses for trophy mounting or educational display. In chemistry, it is often used as an electrolyte. Electrolytes are usually salt-based, and sodium carbonate acts as a very good conductor in the process of electrolysis. In addition, unlike chloride ions, which form chlorine gas, carbonate ions are not corrosive to the anodes. It is also used as a primary standard for acid-base titrations because it is solid and air-stable, making it easy to weigh accurately.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_carbonate",
+      "wikidata": "Q190227"
+    },
+    {
+      "title": "Sodium carbonates",
+      "eNumber": "E500",
+      "synonyms": [
+        "E500",
+        "Sodium carbonates"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium carbonate, Na2CO3, -also known as washing soda, soda ash and soda crystals, and in the monohydrate form as crystal carbonate- is the water-soluble sodium salt of carbonic acid. It most commonly occurs as a crystalline decahydrate, which readily effloresces to form a white powder, the monohydrate. Pure sodium carbonate is a white, odorless powder that is hygroscopic -absorbs moisture from the air-. It has a strongly alkaline taste, and forms a moderately basic solution in water. Sodium carbonate is well known domestically for its everyday use as a water softener. Historically it was extracted from the ashes of plants growing in sodium-rich soils, such as vegetation from the Middle East, kelp from Scotland and seaweed from Spain. Because the ashes of these sodium-rich plants were noticeably different from ashes of timber -used to create potash-, they became known as \"soda ash\". It is synthetically produced in large quantities from salt -sodium chloride- and limestone by a method known as the Solvay process. The manufacture of glass is one of the most important uses of sodium carbonate. Sodium carbonate acts as a flux for silica, lowering the melting point of the mixture to something achievable without special materials. This \"soda glass\" is mildly water-soluble, so some calcium carbonate is added to the melt mixture to make the glass produced insoluble. This type of glass is known as soda lime glass: \"soda\" for the sodium carbonate and \"lime\" for the calcium carbonate. Soda lime glass has been the most common form of glass for centuries. Sodium carbonate is also used as a relatively strong base in various settings. For example, it is used as a pH regulator to maintain stable alkaline conditions necessary for the action of the majority of photographic film developing agents. It acts as an alkali because when dissolved in water, it dissociates into the weak acid: carbonic acid and the strong alkali: sodium hydroxide. This gives sodium carbonate in solution the ability to attack metals such as aluminium with the release of hydrogen gas.It is a common additive in swimming pools used to raise the pH which can be lowered by chlorine tablets and other additives which contain acids. In cooking, it is sometimes used in place of sodium hydroxide for lyeing, especially with German pretzels and lye rolls. These dishes are treated with a solution of an alkaline substance to change the pH of the surface of the food and improve browning. In taxidermy, sodium carbonate added to boiling water will remove flesh from the bones of animal carcasses for trophy mounting or educational display. In chemistry, it is often used as an electrolyte. Electrolytes are usually salt-based, and sodium carbonate acts as a very good conductor in the process of electrolysis. In addition, unlike chloride ions, which form chlorine gas, carbonate ions are not corrosive to the anodes. It is also used as a primary standard for acid-base titrations because it is solid and air-stable, making it easy to weigh accurately.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_carbonate",
+      "wikidata": "Q190227"
+    },
+    {
+      "title": "Sodium carboxy methyl cellulose",
+      "eNumber": "E466",
+      "synonyms": [
+        "E466",
+        "Sodium carboxy methyl cellulose",
+        "sodium carboxymethylcellulose",
+        "carboxy methyl cellulose",
+        "Carboxymethylcellulose",
+        "cellulose gum",
+        "carboxymethyl cellulose",
+        "CMC",
+        "NaCMC"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Carboxymethyl cellulose -CMC- or cellulose gum or tylose powder is a cellulose derivative with carboxymethyl groups --CH2-COOH- bound to some of the hydroxyl groups of the glucopyranose monomers that make up the cellulose backbone. It is often used as its sodium salt, sodium carboxymethyl cellulose.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Carboxymethyl_cellulose",
+      "wikidata": "Q411030"
+    },
+    {
+      "title": "Sodium citrates",
+      "eNumber": "E331",
+      "synonyms": [
+        "E331",
+        "Sodium citrates"
+      ],
+      "functions": [
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Sodium citrate may refer to any of the sodium salts of citrate -though most commonly the third-:  Monosodium citrate Disodium citrate Trisodium citrateThe three forms of the salt are collectively known by the E number E331. Sodium citrates are used as acidity regulators in food and drinks, and also as emulsifiers for oils. They enable cheeses to melt without becoming greasy.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_citrate",
+      "wikidata": "Q6460572"
+    },
+    {
+      "title": "Sodium dehydroacetate",
+      "eNumber": "E266",
+      "synonyms": [
+        "E266",
+        "Sodium dehydroacetate"
+      ],
+      "functions": [],
+      "description": "Sodium dehydroacetate is a compound with the formula Na-CH3C5HO-O2--CH3-CO-. It is the sodium salt of dehydroacetic acid. It has E number E266.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_dehydroacetate",
+      "wikidata": "Q7553316"
+    },
+    {
+      "title": "Sodium diacetate",
+      "eNumber": "E262II",
+      "synonyms": [
+        "E262ii",
+        "Sodium diacetate"
+      ],
+      "functions": [
+        "preservative",
+        "sequestrant"
+      ],
+      "description": "Sodium acetate, CH3COONa, also abbreviated NaOAc, is the sodium salt of acetic acid. This colorless deliquescent salt has a wide range of uses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_diacetate",
+      "wikidata": "Q409655"
+    },
+    {
+      "title": "sodium dodecyl sulfate",
+      "eNumber": "E487",
+      "synonyms": [
+        "E487",
+        "sodium dodecyl sulfate",
+        "sodium laurilsulfate",
+        "sodium lauryl sulfate",
+        "NaDS"
+      ],
+      "functions": [],
+      "description": "Sodium dodecyl sulfate -SDS-, synonymously sodium lauryl sulfate -SLS-, or sodium laurilsulfate, is a synthetic organic compound with the formula CH3-CH2-11SO4 Na.  It is an anionic surfactant used in many cleaning and hygiene products. The sodium salt is of an organosulfate class of organics. It consists of a 12-carbon tail attached to a sulfate group, that is, it is the sodium salt of dodecyl hydrogen sulfate, the ester of dodecyl alcohol and sulfuric acid. Its hydrocarbon tail combined with a polar \"headgroup\" give the compound amphiphilic properties and so make it useful as a detergent.  Also derived as a component of mixtures produced from inexpensive coconut and palm oils, SDS is a common component of many domestic cleaning, personal hygiene and cosmetic, pharmaceutical, and food products, as well as of industrial and commercial cleaning and product formulations.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_dodecyl_sulfate",
+      "wikidata": "Q422241"
+    },
+    {
+      "title": "sodium erythorbate",
+      "eNumber": "E316",
+      "synonyms": [
+        "E316",
+        "sodium erythorbate"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "Sodium erythorbate -C6H7NaO6- is a food additive used predominantly in meats, poultry, and soft drinks. Chemically, it is the sodium salt of erythorbic acid.  When used in processed meat such as hot dogs and beef sticks, it increases the rate at which nitrite reduces to nitric oxide, thus facilitating a faster cure and retaining the pink coloring. As an antioxidant structurally related to vitamin C, it helps improve flavor stability and prevents the formation of carcinogenic nitrosamines. When used as a food additive, its E number is E316. The use of erythorbic acid and sodium erythorbate as a food preservative has increased greatly since the U.S. Food and Drug Administration banned the use of sulfites as preservatives in foods intended to be eaten fresh -such as ingredients for fresh salads- and as food processors have responded to the fact that some people are allergic to sulfites. It can also be found in bologna, and is occasionally used in beverages, baked goods, and potato salad.Sodium erythorbate is produced from sugars derived from different sources, such as beets, sugar cane, and corn. An urban myth claims that sodium erythorbate is made from ground earthworms; however, there is no truth to the myth.   It is thought that the genesis of the legend comes from the similarity of the chemical name to the words earthworm and bait.Alternative applications include the development of additives that could be utilized as anti-oxidants in general. For instance, this substance has been implemented in the development of corrosion inhibitors for metals and it has been implemented in active packaging.Sodium erythorbate is soluble in water. The pH of the aqueous solution of the sodium salt is between 5 and 6. A 10% solution, made from commercial grade sodium erythorbate, may have a pH of 7.2 to 7.9. In its dry, crystalline state it is nonreactive. But, when in solution with water it readily reacts with atmospheric oxygen and other oxidizing agents, which makes it a valuable antioxidant.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_erythorbate",
+      "wikidata": "Q417003"
+    },
+    {
+      "title": "Sodium ethyl p-hydroxybenzoate",
+      "eNumber": "E215",
+      "synonyms": [
+        "E215",
+        "Sodium ethyl p-hydroxybenzoate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Sodium ferrocyanide",
+      "eNumber": "E535",
+      "synonyms": [
+        "E535",
+        "Sodium ferrocyanide",
+        "Yellow prussiate of soda"
+      ],
+      "functions": [],
+      "description": "Sodium ferrocyanide is the sodium salt of the coordination compound of formula [Fe-CN-6]4−. In its hydrous form, Na4Fe-CN-6 · 10 H2O -sodium ferrocyanide decahydrate-, it is sometimes known as yellow prussiate of soda. It is a yellow crystalline solid that is soluble in water and insoluble in alcohol. The yellow color is the color of ferrocyanide anion. Despite the presence of the cyanide ligands, sodium ferrocyanide has low toxicity -acceptable daily intake 0–0.025 mg/kg  body weight-. The ferrocyanides are less toxic than many salts of cyanide, because they tend not to release free cyanide. However, like all ferrocyanide salt solutions, addition of an acid can result in the production of hydrogen cyanide gas, which is toxic.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_ferrocyanide",
+      "wikidata": "Q418474"
+    },
+    {
+      "title": "Sodium formiate",
+      "eNumber": "E237",
+      "synonyms": [
+        "E237",
+        "Sodium formiate",
+        "Sodium formate"
+      ],
+      "functions": [],
+      "description": "Sodium formate, HCOONa, is the sodium salt of formic acid, HCOOH. It usually appears as a white deliquescent powder.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_formate",
+      "wikidata": "Q409209"
+    },
+    {
+      "title": "Sodium fumarate",
+      "eNumber": "E365",
+      "synonyms": [
+        "E365",
+        "Sodium fumarate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Sodium gluconate",
+      "eNumber": "E576",
+      "synonyms": [
+        "E576",
+        "Sodium gluconate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium gluconate is a compound with formula NaC6H11O7. It is the sodium salt of gluconic acid.  Its E number is E576. Sodium gluconate is widely used in textile dyeing, printing and metal surface water treatment.  It is also used as a chelating agent, a steel surface cleaning agent, a cleaning agent for glass bottles, and as a chelating agent for cement, plating and alumina dyeing industries.  It is a white powder that is very soluble in water.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_gluconate",
+      "wikidata": "Q264552"
+    },
+    {
+      "title": "Sodium hydrogen carbonate",
+      "eNumber": "E500II",
+      "synonyms": [
+        "E500ii",
+        "Sodium hydrogen carbonate",
+        "Sodium bicarbonate",
+        "sodium acid carbonate",
+        "Bicarbonate of soda",
+        "baking soda"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium carbonate, Na2CO3, -also known as washing soda, soda ash and soda crystals, and in the monohydrate form as crystal carbonate- is the water-soluble sodium salt of carbonic acid. It most commonly occurs as a crystalline decahydrate, which readily effloresces to form a white powder, the monohydrate. Pure sodium carbonate is a white, odorless powder that is hygroscopic -absorbs moisture from the air-. It has a strongly alkaline taste, and forms a moderately basic solution in water. Sodium carbonate is well known domestically for its everyday use as a water softener. Historically it was extracted from the ashes of plants growing in sodium-rich soils, such as vegetation from the Middle East, kelp from Scotland and seaweed from Spain. Because the ashes of these sodium-rich plants were noticeably different from ashes of timber -used to create potash-, they became known as \"soda ash\". It is synthetically produced in large quantities from salt -sodium chloride- and limestone by a method known as the Solvay process. The manufacture of glass is one of the most important uses of sodium carbonate. Sodium carbonate acts as a flux for silica, lowering the melting point of the mixture to something achievable without special materials. This \"soda glass\" is mildly water-soluble, so some calcium carbonate is added to the melt mixture to make the glass produced insoluble. This type of glass is known as soda lime glass: \"soda\" for the sodium carbonate and \"lime\" for the calcium carbonate. Soda lime glass has been the most common form of glass for centuries. Sodium carbonate is also used as a relatively strong base in various settings. For example, it is used as a pH regulator to maintain stable alkaline conditions necessary for the action of the majority of photographic film developing agents. It acts as an alkali because when dissolved in water, it dissociates into the weak acid: carbonic acid and the strong alkali: sodium hydroxide. This gives sodium carbonate in solution the ability to attack metals such as aluminium with the release of hydrogen gas.It is a common additive in swimming pools used to raise the pH which can be lowered by chlorine tablets and other additives which contain acids. In cooking, it is sometimes used in place of sodium hydroxide for lyeing, especially with German pretzels and lye rolls. These dishes are treated with a solution of an alkaline substance to change the pH of the surface of the food and improve browning. In taxidermy, sodium carbonate added to boiling water will remove flesh from the bones of animal carcasses for trophy mounting or educational display. In chemistry, it is often used as an electrolyte. Electrolytes are usually salt-based, and sodium carbonate acts as a very good conductor in the process of electrolysis. In addition, unlike chloride ions, which form chlorine gas, carbonate ions are not corrosive to the anodes. It is also used as a primary standard for acid-base titrations because it is solid and air-stable, making it easy to weigh accurately.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_bicarbonate",
+      "wikidata": "Q179731"
+    },
+    {
+      "title": "Sodium hydrogen malate",
+      "eNumber": "E350II",
+      "synonyms": [
+        "E350ii",
+        "Sodium hydrogen malate"
+      ],
+      "functions": [
+        "humectant"
+      ],
+      "description": "Sodium malate is a compound with formula Na2-C2H4O-COO-2-. It is the sodium salt of malic acid.  As a food additive, it has the E number E350.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_malate",
+      "wikidata": "Q42807545"
+    },
+    {
+      "title": "Sodium hydrogen sulphate",
+      "eNumber": "E514II",
+      "synonyms": [
+        "E514ii",
+        "Sodium hydrogen sulphate",
+        "Acid sodium sulphate",
+        "Sodium bisulphate"
+      ],
+      "functions": [],
+      "description": "Sodium sulfate -also known as sodium sulphate or sulfate of soda- is the inorganic compound with formula Na2SO4 as well as several related hydrates. All forms are white solids that are highly soluble in water. With an annual production of 6 million tonnes, the decahydrate is a major commodity chemical product.  It is mainly used for the manufacture of detergents and in the kraft process of paper pulping.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_sulfate",
+      "wikidata": "Q211737"
+    },
+    {
+      "title": "Sodium hydroxide",
+      "eNumber": "E524",
+      "synonyms": [
+        "E524",
+        "Sodium hydroxide",
+        "Caustic soda"
+      ],
+      "functions": [],
+      "description": "Sodium hydroxide, also known as lye and caustic soda, is an inorganic compound with the formula NaOH. It is a white solid ionic compound consisting of sodium cations Na+ and hydroxide anions OH−. Sodium hydroxide is a highly caustic base and alkali that decomposes proteins at ordinary ambient temperatures and may cause severe chemical burns. It is highly soluble in water, and readily absorbs moisture and carbon dioxide from the air. It forms a series of hydrates NaOH·nH2O. The monohydrate NaOH·H2O crystallizes from water solutions between 12.3 and 61.8 °C. The commercially available \"sodium hydroxide\" is often this monohydrate, and published data may refer to it instead of the anhydrous compound. As one of the simplest hydroxides, it is frequently utilized alongside neutral water and acidic hydrochloric acid to demonstrate the pH scale to chemistry students.Sodium hydroxide is used in many industries: in the manufacture of pulp and paper, textiles, drinking water, soaps and detergents, and as a drain cleaner. Worldwide production in 2004 was approximately 60 million tonnes, while demand was 51 million tonnes.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_hydroxide",
+      "wikidata": "Q102769"
+    },
+    {
+      "title": "sodium lactate",
+      "eNumber": "E325",
+      "synonyms": [
+        "E325",
+        "sodium lactate"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier",
+        "humectant",
+        "thickener"
+      ],
+      "description": "Sodium lactate is the sodium salt of lactic acid, and has a mild saline taste. It is produced by fermentation of a sugar source, such as corn or beets, and then, by neutralizing the resulting lactic acid to create a compound having the formula NaC3H5O3.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_lactate",
+      "wikidata": "Q418235"
+    },
+    {
+      "title": "Sodium malate",
+      "eNumber": "E350I",
+      "synonyms": [
+        "E350i",
+        "Sodium malate"
+      ],
+      "functions": [
+        "humectant"
+      ],
+      "description": "Sodium malate is a compound with formula Na2-C2H4O-COO-2-. It is the sodium salt of malic acid.  As a food additive, it has the E number E350.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_malate",
+      "wikidata": "Q836788"
+    },
+    {
+      "title": "Sodium malates",
+      "eNumber": "E350",
+      "synonyms": [
+        "E350",
+        "Sodium malates"
+      ],
+      "functions": [
+        "humectant"
+      ],
+      "description": "Sodium malate is a compound with formula Na2-C2H4O-COO-2-. It is the sodium salt of malic acid.  As a food additive, it has the E number E350.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_malate",
+      "wikidata": "Q836788"
+    },
+    {
+      "title": "Sodium metabisulphite",
+      "eNumber": "E223",
+      "synonyms": [
+        "E223",
+        "Sodium metabisulphite",
+        "Pyrosulphite",
+        "Sodium metabisulfite",
+        "Pyrosulfite"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative"
+      ],
+      "description": "Sodium metabisulfite or sodium pyrosulfite -IUPAC spelling; Br. E. sodium metabisulphite or sodium pyrosulphite-  is an inorganic compound of chemical formula Na2S2O5.  The substance is sometimes referred to as disodium metabisulfite.  It is used as a disinfectant, antioxidant, and preservative agent.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_metabisulfite",
+      "wikidata": "Q284549"
+    },
+    {
+      "title": "Sodium methyl p-hydroxybenzoate",
+      "eNumber": "E219",
+      "synonyms": [
+        "E219",
+        "Sodium methyl p-hydroxybenzoate",
+        "sodium methylparaben"
+      ],
+      "functions": [],
+      "description": "Sodium methylparaben -sodium methyl para-hydroxybenzoate- is a compound with formula Na-CH3-C6H4COO-O-. It is the sodium salt of methylparaben. It is a food additive with the E number E219 which is used as a preservative.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_methylparaben",
+      "wikidata": "Q3963920"
+    },
+    {
+      "title": "Sodium nitrate",
+      "eNumber": "E251",
+      "synonyms": [
+        "E251",
+        "Sodium nitrate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sodium nitrate is the chemical compound with the formula NaNO3. This alkali metal nitrate salt is also known as  Chile saltpeter -because large deposits of this salt can be found in Chile- to distinguish it from ordinary saltpeter, potassium nitrate. The mineral form is also known as nitratine, nitratite or soda niter. Sodium nitrate is a white solid very soluble in water. It is a readily available source of the nitrate anion -NO3−-, which is useful in several reactions carried out on industrial scales for the production of fertilizers, pyrotechnics and smoke bombs, glass and pottery enamels, food preservatives -esp. meats-, and solid rocket propellant. It has been mined extensively for these purposes.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_nitrate",
+      "wikidata": "Q184373"
+    },
+    {
+      "title": "Sodium nitrite",
+      "eNumber": "E250",
+      "synonyms": [
+        "E250",
+        "Sodium nitrite",
+        "NaNO2"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sodium nitrite is the inorganic compound with the chemical formula NaNO2. It is a white to slightly yellowish crystalline powder that is very soluble in water and is hygroscopic. It is a useful precursor to a variety of organic compounds, such as pharmaceuticals, dyes, and pesticides, but it is probably best known as a food additive to prevent botulism. It is on the World Health Organization's List of Essential Medicines, the most important medications needed in a basic health system.Nitrate or nitrite -ingested- under conditions that result in endogenous nitrosation has been classified as \"probably carcinogenic to humans\" by International Agency for Research on Cancer -IARC-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_nitrite",
+      "wikidata": "Q339975"
+    },
+    {
+      "title": "Sodium orthophenyl phenol",
+      "eNumber": "E232",
+      "synonyms": [
+        "E232",
+        "Sodium orthophenyl phenol"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sodium orthophenyl phenol is a compound used as a disinfectant. It is the sodium salt of 2-phenylphenol. As a food additive, it has E number E232.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_orthophenyl_phenol",
+      "wikidata": "Q6581446"
+    },
+    {
+      "title": "Sodium phosphates",
+      "eNumber": "E339",
+      "synonyms": [
+        "E339",
+        "Sodium phosphates",
+        "sodium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "preservative",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium phosphate is a generic term for a variety of salts of sodium -Na+- and phosphate -PO43−-. Phosphate also forms families or condensed anions including di-, tri-, tetra-, and polyphosphates. Most of these salts are known in both anhydrous -water-free- and hydrated forms. The hydrates are more common than the anhydrous forms.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_phosphates",
+      "wikidata": "Q3249706"
+    },
+    {
+      "title": "Sodium polyphosphate",
+      "eNumber": "E452I",
+      "synonyms": [
+        "E452i",
+        "Sodium polyphosphate",
+        "sodium hexametaphosphate",
+        "sodium polymetaphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q11867365"
+    },
+    {
+      "title": "Sodium propionate",
+      "eNumber": "E281",
+      "synonyms": [
+        "E281",
+        "Sodium propionate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sodium propanoate or sodium propionate is the sodium salt of propionic acid which has the chemical formula Na-C2H5COO-. This white crystalline solid is deliquescent in moist air.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_propionate",
+      "wikidata": "Q420130"
+    },
+    {
+      "title": "Sodium propyl para-hydroxybenzoate",
+      "eNumber": "E217",
+      "synonyms": [
+        "E217",
+        "Sodium propyl para-hydroxybenzoate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967279"
+    },
+    {
+      "title": "Sodium salts of fatty acids",
+      "eNumber": "E470AI",
+      "synonyms": [
+        "E470ai",
+        "Sodium salts of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Sodium sesquicarbonate",
+      "eNumber": "E500III",
+      "synonyms": [
+        "E500iii",
+        "Sodium sesquicarbonate"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium carbonate, Na2CO3, -also known as washing soda, soda ash and soda crystals, and in the monohydrate form as crystal carbonate- is the water-soluble sodium salt of carbonic acid. It most commonly occurs as a crystalline decahydrate, which readily effloresces to form a white powder, the monohydrate. Pure sodium carbonate is a white, odorless powder that is hygroscopic -absorbs moisture from the air-. It has a strongly alkaline taste, and forms a moderately basic solution in water. Sodium carbonate is well known domestically for its everyday use as a water softener. Historically it was extracted from the ashes of plants growing in sodium-rich soils, such as vegetation from the Middle East, kelp from Scotland and seaweed from Spain. Because the ashes of these sodium-rich plants were noticeably different from ashes of timber -used to create potash-, they became known as \"soda ash\". It is synthetically produced in large quantities from salt -sodium chloride- and limestone by a method known as the Solvay process. The manufacture of glass is one of the most important uses of sodium carbonate. Sodium carbonate acts as a flux for silica, lowering the melting point of the mixture to something achievable without special materials. This \"soda glass\" is mildly water-soluble, so some calcium carbonate is added to the melt mixture to make the glass produced insoluble. This type of glass is known as soda lime glass: \"soda\" for the sodium carbonate and \"lime\" for the calcium carbonate. Soda lime glass has been the most common form of glass for centuries. Sodium carbonate is also used as a relatively strong base in various settings. For example, it is used as a pH regulator to maintain stable alkaline conditions necessary for the action of the majority of photographic film developing agents. It acts as an alkali because when dissolved in water, it dissociates into the weak acid: carbonic acid and the strong alkali: sodium hydroxide. This gives sodium carbonate in solution the ability to attack metals such as aluminium with the release of hydrogen gas.It is a common additive in swimming pools used to raise the pH which can be lowered by chlorine tablets and other additives which contain acids. In cooking, it is sometimes used in place of sodium hydroxide for lyeing, especially with German pretzels and lye rolls. These dishes are treated with a solution of an alkaline substance to change the pH of the surface of the food and improve browning. In taxidermy, sodium carbonate added to boiling water will remove flesh from the bones of animal carcasses for trophy mounting or educational display. In chemistry, it is often used as an electrolyte. Electrolytes are usually salt-based, and sodium carbonate acts as a very good conductor in the process of electrolysis. In addition, unlike chloride ions, which form chlorine gas, carbonate ions are not corrosive to the anodes. It is also used as a primary standard for acid-base titrations because it is solid and air-stable, making it easy to weigh accurately.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_carbonate",
+      "wikidata": "Q2234978"
+    },
+    {
+      "title": "Sodium silicate",
+      "eNumber": "E550",
+      "synonyms": [
+        "E550",
+        "Sodium silicate",
+        "Sodium Silicates i‚ Sodium silicate (ii)‚ Sodium metasilicate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18944661"
+    },
+    {
+      "title": "Sodium sorbate",
+      "eNumber": "E201",
+      "synonyms": [
+        "E201",
+        "Sodium sorbate",
+        "sodium (E‚E)-hexa-2‚4-dienoate"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sodium sorbate is the sodium salt of sorbic acid. Its formula is NaC6H7O2 and systematic name is sodium -E,E--hexa-2‚4-dienoate. It is a food additive with E-number E201.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_sorbate",
+      "wikidata": "Q420152"
+    },
+    {
+      "title": "Sodium stearoyl-2-lactylate",
+      "eNumber": "E481",
+      "synonyms": [
+        "E481",
+        "Sodium stearoyl-2-lactylate",
+        "Sodium stearoyl lactylate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Sodium stearoyl-2-lactylate -sodium stearoyl lactylate or SSL- is a versatile, FDA approved food additive used to improve the mix tolerance and volume of processed foods. It is one type of a commercially available lactylate.  SSL is non-toxic, biodegradable, and typically manufactured using biorenewable feedstocks.  Because SSL is a safe and highly effective food additive, it is used in a wide variety of products ranging from baked goods and desserts to pet foods.As described by the Food Chemicals Codex 7th edition, SSL is a cream-colored powder or brittle solid.  SSL is currently manufactured by the esterification of stearic acid with lactic acid and partially neutralized with either food-grade soda ash -sodium carbonate- or caustic soda -concentrated sodium hydroxide-.  Commercial grade SSL is a mixture of sodium salts of stearoyl lactylic acids and minor proportions of other sodium salts of related acids.  The HLB for SSL is 10-12.  SSL is slightly hygroscopic, soluble in ethanol and in hot oil or fat, and dispersible in warm water.  These properties are the reason that SSL is an excellent emulsifier for fat-in-water emulsions and can also function as a humectant.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_stearoyl_lactylate",
+      "wikidata": "Q416058"
+    },
+    {
+      "title": "Sodium sulphate",
+      "eNumber": "E514I",
+      "synonyms": [
+        "E514i",
+        "Sodium sulphate"
+      ],
+      "functions": [],
+      "description": "Sodium sulfate -also known as sodium sulphate or sulfate of soda- is the inorganic compound with formula Na2SO4 as well as several related hydrates. All forms are white solids that are highly soluble in water. With an annual production of 6 million tonnes, the decahydrate is a major commodity chemical product.  It is mainly used for the manufacture of detergents and in the kraft process of paper pulping.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_sulfate",
+      "wikidata": "Q211737"
+    },
+    {
+      "title": "Sodium sulphates",
+      "eNumber": "E514",
+      "synonyms": [
+        "E514",
+        "Sodium sulphates"
+      ],
+      "functions": [],
+      "description": "Sodium sulfate -also known as sodium sulphate or sulfate of soda- is the inorganic compound with formula Na2SO4 as well as several related hydrates. All forms are white solids that are highly soluble in water. With an annual production of 6 million tonnes, the decahydrate is a major commodity chemical product.  It is mainly used for the manufacture of detergents and in the kraft process of paper pulping.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_sulfate",
+      "wikidata": "Q211737"
+    },
+    {
+      "title": "Sodium sulphite",
+      "eNumber": "E221",
+      "synonyms": [
+        "E221",
+        "Sodium sulphite",
+        "Sodium sulfite"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative"
+      ],
+      "description": "Sodium sulfite -sodium sulphite- is a soluble sodium salt of sulfurous acid -sulfite- with the chemical formula Na2SO3. It is a product of sulfur dioxide scrubbing, a part of the flue-gas desulfurization process. It is also used as a preservative to prevent dried fruit from discoloring, and for preserving meats, and is used in the same way as sodium thiosulfate to convert elemental halogens to their respective hydrohalic acids, in photography and for reducing chlorine levels in pools.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_sulfite",
+      "wikidata": "Q407806"
+    },
+    {
+      "title": "Sodium tartrates",
+      "eNumber": "E335",
+      "synonyms": [
+        "E335",
+        "Sodium tartrates"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q58641683"
+    },
+    {
+      "title": "Sodium tetraborate (borax)",
+      "eNumber": "E285",
+      "synonyms": [
+        "E285",
+        "Sodium tetraborate (borax)",
+        "borax",
+        "sodium borate",
+        "sodium tetraborate",
+        "disodium tetraborate"
+      ],
+      "functions": [],
+      "description": "Borax, also known as sodium borate, sodium tetraborate, or disodium tetraborate, is an important boron compound, a mineral, and a salt of boric acid. Powdered  borax is white, consisting of soft colorless crystals that dissolve in water. A number of closely related minerals or chemical compounds that differ in their crystal water content are referred to as borax, but the word is usually used to refer to the decahydrate. Commercially sold borax is partially dehydrated. Borax is a component of many detergents, cosmetics, and enamel glazes. It is used to make buffer solutions in biochemistry, as a fire retardant, as an anti-fungal compound, in the manufacture of fiberglass, as a flux in metallurgy, neutron-capture shields for radioactive sources, a texturing agent in cooking, as a precursor for other boron compounds, and along with its inverse, boric acid, is useful as an insecticide. In artisanal gold mining, the borax method is sometimes used as a substitute for toxic mercury in the gold extraction process. Borax was reportedly used by gold miners in parts of the Philippines in the 1900s.Borax was first discovered in dry lake beds in Tibet and was imported via the Silk Road to the Arabian Peninsula in the 8th Century AD. Borax first came into common use in the late 19th century when Francis Marion Smith's Pacific Coast Borax Company began to market and popularize a large variety of applications under the 20 Mule Team Borax trademark, named for the method by which borax was originally hauled out of the California and Nevada deserts in large enough quantities to make it cheap and commonly available.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Borax",
+      "wikidata": "Q5319"
+    },
+    {
+      "title": "sodium thiosulfate",
+      "eNumber": "E539",
+      "synonyms": [
+        "E539",
+        "sodium thiosulfate"
+      ],
+      "functions": [
+        "antioxidant",
+        "sequestrant"
+      ],
+      "description": "Sodium thiosulfate -sodium thiosulphate- is a chemical and medication.  As a medication it is used to treat cyanide poisoning and pityriasis versicolor.It is an inorganic compound with the formula Na2S2O3.xH2O. Typically it is available as the white or colorless pentahydrate, Na2S2O3·5H2O.   The solid is an efflorescent -loses water readily- crystalline substance that dissolves well in water. It is also called sodium hyposulfite or \"hypo\".It is on the World Health Organization's List of Essential Medicines, the most effective and safe medicines needed in a health system.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_thiosulfate",
+      "wikidata": "Q339866"
+    },
+    {
+      "title": "Sodium tripolyphosphate",
+      "eNumber": "E452VI",
+      "synonyms": [
+        "E452vi",
+        "Sodium tripolyphosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q11867365"
+    },
+    {
+      "title": "Sodium/potassium and calcium salts of fatty acids",
+      "eNumber": "E470A",
+      "synonyms": [
+        "E470a",
+        "Sodium/potassium and calcium salts of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Sodium/potassium/calcium and magnesium salts of fatty acids",
+      "eNumber": "E470",
+      "synonyms": [
+        "E470",
+        "Sodium/potassium/calcium and magnesium salts of fatty acids"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Sodiumglycinate",
+      "eNumber": "E640II",
+      "synonyms": [
+        "E640ii",
+        "Sodiumglycinate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967228"
+    },
+    {
+      "title": "Sorbic acid",
+      "eNumber": "E200",
+      "synonyms": [
+        "E200",
+        "Sorbic acid"
+      ],
+      "functions": [
+        "preservative"
+      ],
+      "description": "Sorbic acid, or 2‚4-hexadienoic acid, is a natural organic compound used as a food preservative. It has the chemical formula CH3-CH-4CO2H. It is a colourless solid that is slightly soluble in water and sublimes readily. It was first isolated from the unripe berries of the Sorbus aucuparia -rowan tree-, hence its name.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sorbic_acid",
+      "wikidata": "Q407131"
+    },
+    {
+      "title": "Sorbitan monolaurate",
+      "eNumber": "E493",
+      "synonyms": [
+        "E493",
+        "Sorbitan monolaurate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q15427856"
+    },
+    {
+      "title": "Sorbitan monooleate",
+      "eNumber": "E494",
+      "synonyms": [
+        "E494",
+        "Sorbitan monooleate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18944664"
+    },
+    {
+      "title": "Sorbitan monopalmitate",
+      "eNumber": "E495",
+      "synonyms": [
+        "E495",
+        "Sorbitan monopalmitate"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18601367"
+    },
+    {
+      "title": "Sorbitan monostearate",
+      "eNumber": "E491",
+      "synonyms": [
+        "E491",
+        "Sorbitan monostearate"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "Sorbitan monostearate is an ester of sorbitan -a sorbitol derivative- and stearic acid and is sometimes referred to as a synthetic wax.  It is primarily used as an emulsifier to keep water and oils mixed. Sorbitan monostearate is used in the manufacture of food and healthcare products and is a non-ionic surfactant with emulsifying, dispersing, and wetting properties. It is also employed to create synthetic fibers, metal machining fluid, and brighteners in the leather industry, and as an emulsifier in coatings, pesticides, and various applications in the plastics, food and cosmetics industries. Sorbitans are also known as \"Spans\".  Sorbitan monostearate has been approved by the European Union for use as a food additive -emulsifier- -E number: E 491-",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sorbitan_monostearate",
+      "wikidata": "Q907898"
+    },
+    {
+      "title": "Sorbitan trioleate",
+      "eNumber": "E496",
+      "synonyms": [
+        "E496",
+        "Sorbitan trioleate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18601524"
+    },
+    {
+      "title": "Sorbitan tristearate",
+      "eNumber": "E492",
+      "synonyms": [
+        "E492",
+        "Sorbitan tristearate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Sorbitan tristearate is a nonionic surfactant. It is variously used as a dispersing agent, emulsifier, and stabilizer, in food and in aerosol sprays.  As a food additive, it has the E number E492. Brand names for polysorbates include Alkest, Canarcel, and Span. The consistency of sorbitan tristearate is waxy; its color is light cream to tan.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sorbitan_tristearate",
+      "wikidata": "Q1416224"
+    },
+    {
+      "title": "Sorbitol",
+      "eNumber": "E420",
+      "synonyms": [
+        "E420",
+        "Sorbitol",
+        "glucitol"
+      ],
+      "functions": [
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Sorbitol --, less commonly known as glucitol --, is a sugar alcohol with a sweet taste which the human body metabolizes slowly. It can be obtained by reduction of glucose, which changes the aldehyde group to a hydroxyl group. Most sorbitol is made from corn syrup, but it is also found in nature, for example in apples, pears, peaches, and prunes. It is converted to fructose by sorbitol-6-phosphate 2-dehydrogenase. Sorbitol is an isomer of mannitol, another sugar alcohol; the two differ only in the orientation of the hydroxyl group on carbon 2. While similar, the two sugar alcohols have very different sources in nature, melting points, and uses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sorbitol",
+      "wikidata": "Q245280"
+    },
+    {
+      "title": "Sorbitol syrup",
+      "eNumber": "E420II",
+      "synonyms": [
+        "E420ii",
+        "Sorbitol syrup"
+      ],
+      "functions": [
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "sweetener",
+        "thickener"
+      ],
+      "description": "Sorbitol --, less commonly known as glucitol --, is a sugar alcohol with a sweet taste which the human body metabolizes slowly. It can be obtained by reduction of glucose, which changes the aldehyde group to a hydroxyl group. Most sorbitol is made from corn syrup, but it is also found in nature, for example in apples, pears, peaches, and prunes. It is converted to fructose by sorbitol-6-phosphate 2-dehydrogenase. Sorbitol is an isomer of mannitol, another sugar alcohol; the two differ only in the orientation of the hydroxyl group on carbon 2. While similar, the two sugar alcohols have very different sources in nature, melting points, and uses.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sorbitol",
+      "wikidata": "Q245280"
+    },
+    {
+      "title": "Soybean hemicellulose",
+      "eNumber": "E426",
+      "synonyms": [
+        "E426",
+        "Soybean hemicellulose"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967285"
+    },
+    {
+      "title": "Spermaceti",
+      "eNumber": "E909",
+      "synonyms": [
+        "E909",
+        "Spermaceti"
+      ],
+      "functions": [],
+      "description": "Spermaceti -from Greek sperma meaning \"seed\", and ceti, the genitive form of \"whale\"- is a waxy substance found in the head cavities of the sperm whale -and, in smaller quantities, in the oils of other whales-. Spermaceti is created in the spermaceti organ inside the whale's head. This organ may contain as much as 1‚900 litres -500 US gal- of spermaceti.Two theories for the spermaceti organ's biological function suggest it either controls buoyancy, or acts as a focusing apparatus for the whale's sense of echolocation. There has been concrete evidence to support both theories. The buoyancy theory holds that the sperm whale is capable of heating the spermaceti, lowering its density and thus allowing the whale to float; in order for the whale to sink again, it must take water into its blowhole which cools the spermaceti into a denser solid. This claim has been called into question by recent research which indicates a lack of biological structures to support this heat exchange, as well as the fact that the change in density is too small to be meaningful until the organ grows to huge size.The proportion of wax esters in the spermaceti organ increases with the age of the whale: 38–51% in calves, 58–87% in adult females, and 71–94% in adult males. Spermaceti wax is extracted from sperm oil by crystallisation at 6 °C -43 °F-, when treated by pressure and a chemical solution of caustic alkali. Spermaceti forms brilliant white crystals that are hard but oily to the touch, and are devoid of taste or smell, making it very useful as an ingredient in cosmetics, leatherworking, and lubricants. The substance was also used in making candles of a standard photometric value, in the dressing of fabrics, and as a pharmaceutical excipient, especially in cerates and ointments. Candlepower, a photometric unit defined in the United Kingdom Act of Parliament Metropolitan Gas Act 1860 and adopted at the International Electrotechnical Conference of 1883, was based on the light produced by a pure spermaceti candle.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Spermaceti",
+      "wikidata": "Q369682"
+    },
+    {
+      "title": "Stannous chloride",
+      "eNumber": "E512",
+      "synonyms": [
+        "E512",
+        "Stannous chloride",
+        "Tin chloride",
+        "TinII chloride"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "TinII chloride, also known as stannous chloride, is a white crystalline solid with the formula SnCl2. It forms a stable dihydrate, but aqueous solutions tend to undergo hydrolysis, particularly if hot. SnCl2 is widely used as a reducing agent -in acid solution-, and in electrolytic baths for tin-plating. Tin-II- chloride should not be confused with the other chloride of tin; tin-IV- chloride or stannic chloride -SnCl4-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/TinII_chloride",
+      "wikidata": "Q204964"
+    },
+    {
+      "title": "Starch aluminium octenyl succinate",
+      "eNumber": "E1452",
+      "synonyms": [
+        "E1452",
+        "Starch aluminium octenyl succinate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967287"
+    },
+    {
+      "title": "Starch sodium octenyl succinate",
+      "eNumber": "E1450",
+      "synonyms": [
+        "E1450",
+        "Starch sodium octenyl succinate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18967290"
+    },
+    {
+      "title": "Stearyl citrate",
+      "eNumber": "E484",
+      "synonyms": [
+        "E484",
+        "Stearyl citrate"
+      ],
+      "functions": [
+        "antioxidant",
+        "emulsifier",
+        "sequestrant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18608830"
+    },
+    {
+      "title": "Stearyl tartrate",
+      "eNumber": "E483",
+      "synonyms": [
+        "E483",
+        "Stearyl tartrate",
+        "Stearyl palmityl tartrate"
+      ],
+      "functions": [],
+      "description": "Stearyl palmityl tartrate is a derivative of tartaric acid used as an emulsifier. It is produced by esterification of tartaric acid with commercial grade stearyl alcohol, which generally consists of a mixture of the fatty alcohols stearyl and palmityl alcohol. Stearyl palmityl tartrate consists mainly of diesters, with minor amounts of monoester and of unchanged starting materials.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Stearyl_palmityl_tartrate",
+      "wikidata": "Q673260"
+    },
+    {
+      "title": "Steviol glycosides",
+      "eNumber": "E960",
+      "synonyms": [
+        "E960",
+        "Steviol glycosides",
+        "Steviol glycoside",
+        "stevia rebaudiana extract",
+        "stevia leaf extract",
+        "steviol"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Steviol glycosides are the chemical compounds responsible for the sweet taste of the leaves of the South American plant Stevia rebaudiana -Asteraceae- and the main ingredients -or precursors- of many sweeteners marketed under the generic name stevia and several trade names.  They also occur in the related species Stevia phlebophylla -but in no other species of Stevia- and in the plant Rubus chingii -Rosaceae-.Steviol glycosides from Stevia rebaudiana have been reported to be between 30 and 320 times sweeter than sucrose, although there is some disagreement in the technical literature about these numbers. They are heat-stable, pH-stable, and do not ferment.  Additionally, they do not induce a glycemic response when ingested, because humans can not metabolize stevia. This makes them attractive as natural sugar substitutes for diabetics and other people on carbohydrate-controlled diets. Steviol glycosides stimulate the insulin secretion through potentiation of the β-cell, preventing high blood glucose after a meal.  The acceptable daily intake -ADI- for steviol glycosides, expressed as steviol equivalents, has been established to be 4 mg/kg body weight/day, and is based on no observed effects of a 100 fold higher dose in a rat study.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Steviol_glycoside",
+      "wikidata": "Q2805600"
+    },
+    {
+      "title": "Steviol glycosides from Stevia",
+      "eNumber": "E960A",
+      "synonyms": [
+        "E960a",
+        "Steviol glycosides from Stevia"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Succinic acid",
+      "eNumber": "E363",
+      "synonyms": [
+        "E363",
+        "Succinic acid",
+        "Asuccin",
+        "Amber acid",
+        "1/2-Ethanedicarboxylic acid",
+        "Butanedioic acid",
+        "Bernsteinsaeure",
+        "Ethylenesuccinic acid",
+        "Spirit of amber",
+        "Butanedionic acid",
+        "Bernsteinsaure",
+        "Succinate",
+        "Butandisaeure",
+        "Dihydrofumaric acid",
+        "Acidum succinicum",
+        "Acide butanedioique",
+        "Acide succinique"
+      ],
+      "functions": [],
+      "description": "Succinic acid --  is a dicarboxylic acid with the chemical formula -CH2-2-CO2H-2.  The name derives from Latin succinum, meaning amber. In living organisms, succinic acid takes the form of an anion, succinate, which has multiple biological roles as a metabolic intermediate being converted into fumarate by the enzyme succinate dehydrogenase in complex 2 of the electron transport chain which is involved in making ATP, and as a signaling molecule reflecting the cellular metabolic state. Succinate is generated in mitochondria via the tricarboxylic acid cycle -TCA-, an energy-yielding process shared by all organisms. Succinate can exit the mitochondrial matrix and function in the cytoplasm as well as the extracellular space, changing gene expression patterns, modulating epigenetic landscape or demonstrating hormone-like signaling. As such, succinate links cellular metabolism, especially ATP formation, to the regulation of cellular function. Dysregulation of succinate synthesis, and therefore ATP synthesis, happens in some genetic mitochondrial diseases, such as Leigh syndrome, and Melas syndrome, and degradation can lead to pathological conditions, such as malignant transformation, inflammation and tissue injury.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Succinic_acid",
+      "wikidata": "Q213050"
+    },
+    {
+      "title": "Succinylated monoglycerides",
+      "eNumber": "E472G",
+      "synonyms": [
+        "E472g",
+        "Succinylated monoglycerides"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Succistearin",
+      "eNumber": "E446",
+      "synonyms": [
+        "E446",
+        "Succistearin"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18601547"
+    },
+    {
+      "title": "Sucralose",
+      "eNumber": "E955",
+      "synonyms": [
+        "E955",
+        "Sucralose"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "Sucralose is an artificial sweetener and sugar substitute. The majority of ingested sucralose is not broken down by the body, so it is noncaloric. In the European Union, it is also known under the E number E955. It is produced by chlorination of sucrose. Sucralose is about 320 to 1‚000 times sweeter than sucrose, three times as sweet as both aspartame and  acesulfame potassium, and twice as sweet as sodium saccharin. Evidence of benefit is lacking for long-term weight loss with some data supporting weight gain and heart disease risks.It is stable under heat and over a broad range of pH conditions. Therefore, it can be used in baking or in products that require a long shelf life. The commercial success of sucralose-based products stems from its favorable comparison to other low-calorie sweeteners in terms of taste, stability, and safety. Common brand names of sucralose-based sweeteners are Splenda, Zerocal, Sukrana,  SucraPlus, Candys, Cukren, and Nevella. Canderel Yellow also contains sucralose, but the original Canderel and Green Canderel do not.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sucralose",
+      "wikidata": "Q410209"
+    },
+    {
+      "title": "Sucroglycerides",
+      "eNumber": "E474",
+      "synonyms": [
+        "E474",
+        "Sucroglycerides",
+        "Sucroglyceride"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q18608931"
+    },
+    {
+      "title": "Sucrose acetate isobutyrate",
+      "eNumber": "E444",
+      "synonyms": [
+        "E444",
+        "Sucrose acetate isobutyrate"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "Sucrose acetoisobutyrate -SAIB- is an emulsifier and has E number E444. In the United States, SAIB is categorized as generally recognized as safe -GRAS- as a food additive in cocktail mixers, beer, malt beverages, or wine coolers and is a potential replacement for brominated vegetable oil.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sucrose_acetate_isobutyrate",
+      "wikidata": "Q410537"
+    },
+    {
+      "title": "Sucrose esters of fatty acids",
+      "eNumber": "E473",
+      "synonyms": [
+        "E473",
+        "Sucrose esters of fatty acids",
+        "Sucroesters",
+        "sugar ester",
+        "sucrose esters"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sucrose_esters",
+      "wikidata": "Q55648666"
+    },
+    {
+      "title": "Sulphite ammonia caramel",
+      "eNumber": "E150D",
+      "synonyms": [
+        "E150d",
+        "Sulphite ammonia caramel",
+        "Sulfite ammonia caramel",
+        "Caramel Colour Ammonium Sulphite Process",
+        "Colour Sulphite Ammonia Caramel",
+        "Colour E150d",
+        "Food Colour 150d",
+        "CAS 8028-89-5",
+        "acid-proof caramel",
+        "soft-drink caramel"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081740"
+    },
+    {
+      "title": "Sulphur dioxide",
+      "eNumber": "E220",
+      "synonyms": [
+        "E220",
+        "Sulphur dioxide",
+        "Sulfur dioxide"
+      ],
+      "functions": [
+        "antioxidant",
+        "preservative"
+      ],
+      "description": "Sulfur dioxide -also sulphur dioxide in British English- is the chemical compound with the formula SO2. It is a toxic gas with a burnt match smell. It is released naturally by volcanic activity and is produced as a by-product of the burning of fossil fuels contaminated with sulfur compounds.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sulfur_dioxide",
+      "wikidata": "Q5282"
+    },
+    {
+      "title": "Sulphuric acid",
+      "eNumber": "E513",
+      "synonyms": [
+        "E513",
+        "Sulphuric acid",
+        "Oil of vitriol",
+        "sulfuric acid",
+        "H2SO4"
+      ],
+      "functions": [],
+      "description": "Sulfuric acid -alternative spelling sulphuric acid-, also known as vitriol, is a mineral acid composed of the elements sulfur, oxygen and hydrogen, with molecular formula H2SO4. It is a colorless, odorless, and syrupy liquid that is soluble in water, in a reaction that is highly exothermic.Its corrosiveness can be mainly ascribed to its strong acidic nature, and, if at a high concentration, its dehydrating and oxidizing properties. It is also hygroscopic, readily absorbing water vapor from the air. Upon contact, sulfuric acid can cause severe chemical burns and even secondary thermal burns; it is very dangerous even at moderate concentrations.Sulfuric acid is a very important commodity chemical, and indeed, a nation's sulfuric acid production is a good indicator of its industrial strength. It is widely produced with different methods, such as contact process, wet sulfuric acid process, lead chamber process and some other methods.The most common use of sulfuric acid -60% of total- is for fertilizer manufacture. It is also a central substance in the chemical industry. Principal uses include fertilizer manufacturing -and other mineral processing-, oil refining, wastewater processing, and chemical synthesis. It has a wide range of end applications including in domestic acidic drain cleaners, as an electrolyte in lead-acid batteries and in various cleaning agents.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sulfuric_acid",
+      "wikidata": "Q4118"
+    },
+    {
+      "title": "Sunset yellow FCF",
+      "eNumber": "E110",
+      "synonyms": [
+        "E110",
+        "Sunset yellow FCF",
+        "CI Food Yellow 3",
+        "Orange Yellow S",
+        "FD&C Yellow 6",
+        "FD & C Yellow No.6",
+        "FD and C Yellow No. 6",
+        "Yellow No.6",
+        "Yellow 6",
+        "FD and C Yellow 6",
+        "C.I. 15985",
+        "Yellow 6 lake",
+        "Sunset Yellow"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Sunset Yellow FCF -also known as Orange Yellow S, or C.I. 15985- is a petroleum-derived orange azo dye with a pH dependent maximum absorption at about 480 nm at pH 1 and 443 nm at pH 13 with a shoulder at 500 nm.  When added to foods sold in the US it is known as FD&C Yellow 6; when sold in Europe, it is denoted by E Number E110.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sunset_Yellow_FCF",
+      "wikidata": "Q410095"
+    },
+    {
+      "title": "Superglycerinated hydrogenated rapeseed oil",
+      "eNumber": "E441",
+      "synonyms": [
+        "E441",
+        "Superglycerinated hydrogenated rapeseed oil",
+        "Hydrogenated rapeseed oil superglycerinated",
+        "Superglycerinated fully hydrogenated rapeseed oil"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "synthetic magnesium silicates",
+      "eNumber": "E553A",
+      "synonyms": [
+        "E553a",
+        "synthetic magnesium silicates"
+      ],
+      "functions": [
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Synthetic wax",
+      "eNumber": "E905",
+      "synonyms": [
+        "E905",
+        "Synthetic wax",
+        "Hydrocarbon wax",
+        "Fischer-Tropsch wax"
+      ],
+      "functions": [],
+      "description": "Microcrystalline waxes are a type of wax produced by de-oiling petrolatum, as part of the petroleum refining process. In contrast to the more familiar paraffin wax which contains mostly unbranched alkanes, microcrystalline wax contains a higher percentage of isoparaffinic -branched- hydrocarbons and naphthenic hydrocarbons. It is characterized by the fineness of its crystals in contrast to the larger crystal of paraffin wax. It consists of high molecular weight saturated aliphatic hydrocarbons. It is generally darker, more viscous, denser, tackier and more elastic than paraffin waxes, and has a higher molecular weight and melting point. The elastic and adhesive characteristics of microcrystalline waxes are related to the non-straight chain components which they contain. Typical microcrystalline wax crystal structure is small and thin, making them more flexible than paraffin wax. It is commonly used in cosmetic formulations. Microcrystalline waxes when produced by wax refiners are typically produced to meet a number of ASTM specifications. These include congeal point -ASTM D938-, needle penetration -D1321-, color -ASTM D6045-, and viscosity -ASTM D445-. Microcrystalline waxes can generally be put into two categories: \"laminating\" grades and \"hardening\" grades. The laminating grades typically have a melt point of 140-175 F -60 - 80 oC- and needle penetration of 25 or above. The hardening grades will range from about 175-200 F -80 - 93 oC-, and have a needle penetration of 25 or below. Color in both grades can range from brown to white, depending on the degree of processing done at the refinery level. Microcrystalline waxes are derived from the refining of the heavy distillates from lubricant oil production. This by-product must then be de-oiled at a wax refinery. Depending on the end use and desired specification, the product may then have its odor removed and color removed -which typically starts as a brown or dark yellow-. This is usually done by means of a filtration method or by hydro-treating the wax material.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Microcrystalline_wax",
+      "wikidata": "Q579764"
+    },
+    {
+      "title": "Tagatose",
+      "eNumber": "E963",
+      "synonyms": [
+        "E963",
+        "Tagatose"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q414089"
+    },
+    {
+      "title": "Talc",
+      "eNumber": "E553B",
+      "synonyms": [
+        "E553b",
+        "Talc",
+        "talcum",
+        "hydrated magnesium silicate"
+      ],
+      "functions": [
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q134583"
+    },
+    {
+      "title": "Tannin",
+      "eNumber": "E181",
+      "synonyms": [
+        "E181",
+        "Tannin"
+      ],
+      "functions": [
+        "colour",
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Tannins -or tannoids- are a class of astringent, polyphenolic biomolecules that bind to and precipitate proteins and various other organic compounds including amino acids and alkaloids. The term tannin -from tanna, an Old High German word for oak or fir tree, as in Tannenbaum- refers to the use of wood tannins from oak in tanning animal hides into leather; hence the words \"tan\" and \"tanning\" for the treatment of leather. By extension the term \"tannin\" is widely applied to any large polyphenolic compound containing sufficient hydroxyls and other suitable groups -such as carboxyls- to form strong complexes with various macromolecules. The tannin compounds are widely distributed in many species of plants, where they play a role in protection from predation, and perhaps also as pesticides, and might help in regulating plant growth. The astringency from the tannins is what causes the dry and puckery feeling in the mouth following the consumption of unripened fruit, red wine or tea. Likewise, the destruction or modification of tannins with time plays an important role when determining harvesting times. Tannins have molecular weights ranging from 500 to over 3‚000 -gallic acid esters- and up to 20‚000 -proanthocyanidins-.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tannin",
+      "wikidata": "Q187607"
+    },
+    {
+      "title": "Tara gum",
+      "eNumber": "E417",
+      "synonyms": [
+        "E417",
+        "Tara gum"
+      ],
+      "functions": [
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tara_spinosa#Uses",
+      "wikidata": "Q15089452"
+    },
+    {
+      "title": "Tartaric acid esters of mono- and diglycerides of fatty acids",
+      "eNumber": "E472D",
+      "synonyms": [
+        "E472d",
+        "Tartaric acid esters of mono- and diglycerides of fatty acids"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Tartrazine",
+      "eNumber": "E102",
+      "synonyms": [
+        "E102",
+        "Tartrazine",
+        "Yellow 5",
+        "Yellow number 5",
+        "Yellow no 5",
+        "Yellow no5",
+        "FD&C Yellow 5",
+        "FD&C Yellow no 5",
+        "FD&C Yellow no5",
+        "FD and C Yellow no. 5",
+        "FD and C Yellow 5",
+        "Yellow 5 lake"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Tartrazine is a synthetic lemon yellow azo dye primarily used as a food coloring.  It is also known as E number E102, C.I. 19140, FD&C Yellow 5, Acid Yellow 23, Food Yellow 4, and trisodium 1--4-sulfonatophenyl--4--4-sulfonatophenylazo--5-pyrazolone-3-carboxylate-.Tartrazine is a commonly used color all over the world, mainly for yellow, and can also be used with Brilliant Blue FCF -FD&C Blue 1,  E133- or Green S -E142- to produce various green shades.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tartrazine",
+      "wikidata": "Q407158"
+    },
+    {
+      "title": "Tertiary-butylhydroquinone (tbhq)",
+      "eNumber": "E319",
+      "synonyms": [
+        "E319",
+        "Tertiary-butylhydroquinone (tbhq)",
+        "Tert-butyl-1‚4-benzenediol",
+        "Butylhydroxinon",
+        "TBHQ",
+        "Tert-Butylhydroquinone",
+        "tertiary butylhydroquinone"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "tert-Butylhydroquinone -TBHQ, tertiary butylhydroquinone- is a synthetic aromatic organic compound which is a type of phenol. It is a derivative of hydroquinone, substituted with a tert-butyl group.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tert-Butylhydroquinone",
+      "wikidata": "Q662443"
+    },
+    {
+      "title": "Tetrapotassium diphosphate",
+      "eNumber": "E450V",
+      "synonyms": [
+        "E450v",
+        "Tetrapotassium diphosphate",
+        "tetrapotassium pyrophosphate",
+        "e450v"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q290828"
+    },
+    {
+      "title": "Tetrasodium diphosphate",
+      "eNumber": "E450III",
+      "synonyms": [
+        "E450iii",
+        "Tetrasodium diphosphate",
+        "Tetrasodium pyrophosphate",
+        "Tetrasodium disphosphate",
+        "sodium pyrophosphate",
+        "TSPP",
+        "e450iii"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tetrasodium_pyrophosphate",
+      "wikidata": "Q418504"
+    },
+    {
+      "title": "Thaumatin",
+      "eNumber": "E957",
+      "synonyms": [
+        "E957",
+        "Thaumatin"
+      ],
+      "functions": [
+        "sweetener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q414048"
+    },
+    {
+      "title": "Thermally oxidised soya bean oil interacted with mono- and diglycerides of fatty acids",
+      "eNumber": "E479B",
+      "synonyms": [
+        "E479b",
+        "Thermally oxidised soya bean oil interacted with mono- and diglycerides of fatty acids",
+        "Thermally oxidised soya bean oil interacted with mono­ and diglycerides of fatty acids"
+      ],
+      "functions": [
+        "emulsifier"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Thiabendazole",
+      "eNumber": "E233",
+      "synonyms": [
+        "E233",
+        "Thiabendazole"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Thiodipropionic acid",
+      "eNumber": "E388",
+      "synonyms": [
+        "E388",
+        "Thiodipropionic acid"
+      ],
+      "functions": [
+        "antioxidant"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q2823309"
+    },
+    {
+      "title": "Titanium dioxide",
+      "eNumber": "E171",
+      "synonyms": [
+        "E171",
+        "Titanium dioxide"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "Titanium dioxide, also known as titaniumIV oxide or titania, is the naturally occurring oxide of titanium, chemical formula TiO2. When used as a pigment, it is called titanium white, Pigment White 6 -PW6-, or CI 77891. Generally, it is sourced from ilmenite, rutile and anatase. It has a wide range of applications, including paint, sunscreen and food coloring. When used as a food coloring, it has E number E171. World production in 2014 exceeded 9 million metric tons. It has been estimated that titanium dioxide is used in two-thirds of all pigments, and the oxide has been valued at $13.2 billion.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Titanium_dioxide",
+      "wikidata": "Q193521"
+    },
+    {
+      "title": "Tocopherol-rich extract",
+      "eNumber": "E306",
+      "synonyms": [
+        "E306",
+        "Tocopherol-rich extract",
+        "Tocopherols",
+        "natural tocopherols",
+        "mixed tocopherols",
+        "natural mixed tocopherols"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "https://en.wikipedia.org/wiki/Vitamin_E",
+      "wikidata": "Q141180"
+    },
+    {
+      "title": "Tragacanth",
+      "eNumber": "E413",
+      "synonyms": [
+        "E413",
+        "Tragacanth",
+        "Tragacanth gum"
+      ],
+      "functions": [
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Tragacanth is a natural gum obtained from the dried sap of several species of Middle Eastern legumes of the genus Astragalus, including A. adscendens, A. gummifer, A. brachycalyx, and A. tragacantha. Some of these species are known collectively under the common names \"goat's thorn\" and \"locoweed\". The gum is sometimes called Shiraz gum, shiraz, gum elect or gum dragon. The name derives from the Greek words tragos -meaning \"goat\"- and akantha -\"thorn\"-. Iran is the biggest producer of this gum. Gum tragacanth is a viscous, odorless, tasteless, water-soluble mixture of polysaccharides obtained from sap that is drained from the root of the plant and dried. The gum seeps from the plant in twisted ribbons or flakes that can be powdered. It absorbs water to become a gel, which can be stirred into a paste. The major fractions are known as tragacanthin, highly water soluble as a mucilaginous colloid, and the chemically related bassorin, which is far less soluble but swells in water to form a gel. The gum is used in vegetable-tanned leatherworking as an edge slicking and burnishing compound, and is occasionally used as a stiffener in textiles. The gum has been used historically as a herbal remedy for such conditions as cough and diarrhea. As a mucilage or paste, it has been used as a topical treatment for burns. It is used in pharmaceuticals and foods as an emulsifier, thickener, stabilizer, and texturant additive -E number E413-. It is the traditional binder used in the making of artists' pastels, as it does not adhere to itself the same way other gums -such as gum arabic- do when dry. Gum tragacanth is also used to make a paste used in floral sugarcraft to create lifelike flowers on wires used as decorations for cakes, which air-dries brittle and can take colorings. It enables users to get a very fine, delicate finish to their work. It has traditionally been used as an adhesive in the cigar-rolling process used to secure the cap or \"flag\" leaf to the finished cigar body.Gum tragacanth is less common in products than other, usually cheaper, gums, such as gum arabic or guar gum. Different gums tend to be interchangeable across many uses, and production of tragacanth is far outpaced by these for reasons of economy, trade, agriculture and history, while tragacanth is mostly produced in traditional locations. However, gums are used in varied circumstances and there are many situations where tragacanth is considered superior. Common substitutions are methyl cellulose, sometimes marketed as \"substitute gum tragacanth\" in the food industry, and gum karaya. Gum karaya, also called \"Indian tragacanth\" or simply \"tragacanth\", might be fully or partially substituted for what appears to be genuine tragacanth. Gum tragacanth is also used in incense-making as a binder to hold all the powdered herbs together. Its water solubility is ideal for ease of working and an even spread, and it is one of the stronger gums for holding particles in suspension. Only half as much is needed, compared to gum arabic or something similar.In Saudi Arabia, a mixture of hydrated Tragacanth and ground dried Ziziphus spina-christi is used as a natural hair shampoo that is believed to promote hair growth.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tragacanth",
+      "wikidata": "Q423901"
+    },
+    {
+      "title": "Triammonium citrate",
+      "eNumber": "E380",
+      "synonyms": [
+        "E380",
+        "Triammonium citrate"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q13081798"
+    },
+    {
+      "title": "Tricalcium citrate",
+      "eNumber": "E333III",
+      "synonyms": [
+        "E333iii",
+        "Tricalcium citrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Calcium citrate is the calcium salt of citric acid.  It is commonly used as a food additive -E333-, usually as a preservative, but sometimes for flavor.  In this sense, it is similar to sodium citrate.   Calcium citrate is also found in some dietary calcium supplements -e.g. Citracal-. Calcium makes up 24.1% of calcium citrate -anhydrous- and 21.1% of calcium citrate -tetrahydrate- by mass. The tetrahydrate occurs in nature as the mineral Earlandite.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Calcium_citrate",
+      "wikidata": "Q420280"
+    },
+    {
+      "title": "Tricalcium phosphate",
+      "eNumber": "E341III",
+      "synonyms": [
+        "E341iii",
+        "Tricalcium phosphate",
+        "Tricalciumphosphate",
+        "tri-calcium phosphate",
+        "tricalcium phosphate",
+        "E 341iii",
+        "E-341iii",
+        "E341 iii"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Calcium phosphate is a family of materials and minerals containing calcium ions -Ca2+- together with inorganic phosphate anions.  Some so-called calcium phosphates contain oxide and hydroxide as well.  They are white solids of nutritious value.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tricalcium_phosphate",
+      "wikidata": "Q278387"
+    },
+    {
+      "title": "Triethyl citrate",
+      "eNumber": "E1505",
+      "synonyms": [
+        "E1505",
+        "Triethyl citrate",
+        "triethyl 2-hydroxypropane-1‚2‚3-tricarboxylate"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Triethyl citrate is an ester of citric acid.  It is a colorless, odorless liquid used as a food additive -E number E1505- to stabilize foams, especially as whipping aid  for egg white. It is also used in pharmaceutical coatings and plastics.Triethyl citrate is also used as a plasticizer for polyvinyl chloride -PVC- and similar plastics.Triethyl citrate has been used as a pseudo-emulsifier in e-cigarette juices. It functions essentially like lecithin used in food products, but with the possibility of vaporization which lecithin does not have.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Triethyl_citrate",
+      "wikidata": "Q418057"
+    },
+    {
+      "title": "Triphosphates",
+      "eNumber": "E451",
+      "synonyms": [
+        "E451",
+        "Triphosphates",
+        "triphosphate",
+        "E 451",
+        "e-451"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium triphosphate -STP-, also  sodium tripolyphosphate -STPP-, or tripolyphosphate -TPP-,- is an inorganic compound with formula Na5P3O10.  It is the sodium salt of the polyphosphate penta-anion, which is the conjugate base of triphosphoric acid.  It is produced on a large scale as a component of many domestic and industrial products, especially detergents.  Environmental problems associated with eutrophication are attributed to its widespread use.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_triphosphate",
+      "wikidata": "Q29145"
+    },
+    {
+      "title": "Tripotassium citrate",
+      "eNumber": "E332II",
+      "synonyms": [
+        "E332ii",
+        "Tripotassium citrate",
+        "potassium citrate"
+      ],
+      "functions": [
+        "sequestrant",
+        "stabiliser"
+      ],
+      "description": "Potassium citrate -also known as tripotassium citrate- is a potassium salt of citric acid with the molecular formula K3C6H5O7.  It is a white, hygroscopic crystalline powder. It is odorless with a saline taste. It contains 38.28% potassium by mass.  In the monohydrate form it is highly hygroscopic and deliquescent. As a food additive, potassium citrate is used to regulate acidity and is known as E number E332. Medicinally, it may be used to control kidney stones derived from either uric acid or cystine.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Potassium_citrate",
+      "wikidata": "Q419921"
+    },
+    {
+      "title": "Tripotassium phosphate",
+      "eNumber": "E340III",
+      "synonyms": [
+        "E340iii",
+        "Tripotassium phosphate",
+        "tripotassium phosphate",
+        "E 340iii",
+        "E340 iii",
+        "E-340iii",
+        "Tribasic potassium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Potassium phosphate is a generic term for the salts of potassium and phosphate ions including: Monopotassium phosphate -KH2PO4- -Molar mass approx: 136 g/mol- Dipotassium phosphate -K2HPO4- -Molar mass approx: 174 g/mol- Tripotassium phosphate -K3PO4- -Molar mass approx: 212.27 g/mol-As food additives, potassium phosphates have the E number E340.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Tripotassium_phosphate",
+      "wikidata": "Q423852"
+    },
+    {
+      "title": "Trisodium citrate",
+      "eNumber": "E331III",
+      "synonyms": [
+        "E331iii",
+        "Trisodium citrate"
+      ],
+      "functions": [],
+      "description": "Sodium citrate may refer to any of the sodium salts of citrate -though most commonly the third-:  Monosodium citrate Disodium citrate Trisodium citrateThe three forms of the salt are collectively known by the E number E331. Sodium citrates are used as acidity regulators in food and drinks, and also as emulsifiers for oils. They enable cheeses to melt without becoming greasy.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Sodium_citrate",
+      "wikidata": ""
+    },
+    {
+      "title": "Trisodium diphosphate",
+      "eNumber": "E450II",
+      "synonyms": [
+        "E450ii",
+        "Trisodium diphosphate",
+        "e450ii"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q290828"
+    },
+    {
+      "title": "Trisodium phosphate",
+      "eNumber": "E339III",
+      "synonyms": [
+        "E339iii",
+        "Trisodium phosphate",
+        "Tribasic sodium phosphate"
+      ],
+      "functions": [
+        "emulsifier",
+        "humectant",
+        "preservative",
+        "sequestrant",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Sodium phosphate is a generic term for a variety of salts of sodium -Na+- and phosphate -PO43−-. Phosphate also forms families or condensed anions including di-, tri-, tetra-, and polyphosphates. Most of these salts are known in both anhydrous -water-free- and hydrated forms. The hydrates are more common than the anhydrous forms.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Trisodium_phosphate",
+      "wikidata": "Q3249706"
+    },
+    {
+      "title": "Vegetable carbon",
+      "eNumber": "E153",
+      "synonyms": [
+        "E153",
+        "Vegetable carbon"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q59557415"
+    },
+    {
+      "title": "Wax ester",
+      "eNumber": "E910",
+      "synonyms": [
+        "E910",
+        "Wax ester"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q7975685"
+    },
+    {
+      "title": "white and yellow beeswax",
+      "eNumber": "E901",
+      "synonyms": [
+        "E901",
+        "white and yellow beeswax",
+        "beeswax",
+        "white beeswax",
+        "yellow beeswax",
+        "white wax"
+      ],
+      "functions": [
+        "carrier",
+        "emulsifier",
+        "stabiliser",
+        "thickener"
+      ],
+      "description": "Beeswax -cera alba- is a natural wax produced by honey bees of the genus Apis.  The wax is formed into \"scales\" by eight wax-producing glands in the abdominal segments of worker bees, which discard it in or at the hive.  The hive workers collect and use it to form cells for honey storage and larval and pupal protection within the beehive.  Chemically, beeswax consists mainly of esters of fatty acids and various long-chain alcohols. Beeswax has long-standing applications in human food and flavoring.  For example, it is used as a glazing agent or as a light/heat source. It is edible, in the sense of having similar negligible toxicity to plant waxes, and is approved for food use in most countries and the European Union under the E number E901. However, the wax monoesters in beeswax are poorly hydrolysed in the guts of humans and other mammals, so they have insignificant nutritional value. Some birds, such as honeyguides, can digest beeswax. Beeswax is the main diet of wax moth larvae.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Beeswax",
+      "wikidata": "Q143739"
+    },
+    {
       "title": "Xanthan gum",
       "eNumber": "E415",
       "synonyms": [
@@ -200,22 +9346,87 @@
       "wikidata": "Q410768"
     },
     {
-      "title": "Glycerol",
-      "eNumber": "E422",
+      "title": "Xanthophylls",
+      "eNumber": "E161",
       "synonyms": [
-        "E422",
-        "Glycerol",
-        "Glycerin",
-        "Glycerine",
-        "vegetable glycerine"
+        "E161",
+        "Xanthophylls"
+      ],
+      "functions": [],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Xylitol",
+      "eNumber": "E967",
+      "synonyms": [
+        "E967",
+        "Xylitol"
       ],
       "functions": [
+        "emulsifier",
         "humectant",
+        "stabiliser",
+        "sweetener",
         "thickener"
       ],
-      "description": "Glycerol -; also called glycerine or glycerin; see spelling differences- is a simple polyol compound. It is a colorless, odorless, viscous liquid that is sweet-tasting and non-toxic. The glycerol backbone is found in all lipids known as triglycerides. It is widely used in the food industry as a sweetener and humectant and in pharmaceutical formulations. Glycerol has three hydroxyl groups that are responsible for its solubility in water and its hygroscopic nature.",
-      "wikipedia": "https://en.wikipedia.org/wiki/Glycerol",
-      "wikidata": "Q132501"
+      "description": "Xylitol  is a sugar alcohol used as a sweetener.  The name derives from Ancient Greek: ξύλον, xyl[on], \"wood\" + suffix -itol, used to denote sugar alcohols. Xylitol is categorized as a polyalcohol or sugar alcohol -specifically an alditol-. It has the formula CH2OH-CHOH-3CH2OH. It is a colorless or white solid that is soluble in water.  Use of manufactured products containing xylitol may reduce tooth decay.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Xylitol",
+      "wikidata": "Q212093"
+    },
+    {
+      "title": "Yellow 2G",
+      "eNumber": "E107",
+      "synonyms": [
+        "E107",
+        "Yellow 2G"
+      ],
+      "functions": [],
+      "description": "Yellow 2G is a food coloring denoted by E number E107 with the Colour Index CI18965. It has the appearance of a yellow powder, and it is soluble in water. It is a synthetic yellow azo dye. It is not listed by the UK's Food Standards Agency among EU approved food additives. Its use is also banned in Austria, Japan, Norway, Sweden, Switzerland and the United States.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Yellow_2G",
+      "wikidata": "Q424528"
+    },
+    {
+      "title": "Yellow iron oxide",
+      "eNumber": "E172III",
+      "synonyms": [
+        "E172iii",
+        "Yellow iron oxide"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": "Q3045754"
+    },
+    {
+      "title": "Zeaxanthin",
+      "eNumber": "E161H",
+      "synonyms": [
+        "E161h",
+        "Zeaxanthin"
+      ],
+      "functions": [
+        "colour"
+      ],
+      "description": "",
+      "wikipedia": "",
+      "wikidata": ""
+    },
+    {
+      "title": "Zinc acetate",
+      "eNumber": "E650",
+      "synonyms": [
+        "E650",
+        "Zinc acetate",
+        "zinc salt"
+      ],
+      "functions": [],
+      "description": "Zinc acetate is a salt with the formula Zn-O2CCH3-2, which commonly occurs as the dihydrate Zn-O2CCH3-2-H2O-2. Both the hydrate and the anhydrous forms are colorless solids that are commonly used in chemical synthesis and as dietary supplements. Zinc acetates are prepared by the action of acetic acid on zinc carbonate or zinc metal. When used as a food additive, it has the E number E650.",
+      "wikipedia": "https://en.wikipedia.org/wiki/Zinc_acetate",
+      "wikidata": "Q204639"
     }
   ]
 }

--- a/scripts/fetch-additives.js
+++ b/scripts/fetch-additives.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+/**
+ * This script downloads the full list of food additives from Open Food Facts
+ * and stores a normalized snapshot in `data/additives.json`.
+ *
+ * Steps:
+ * 1. Retrieve all additive IDs by paging through the facets API.
+ * 2. Fetch taxonomy details for each additive to collect metadata.
+ * 3. Normalize the data structure (names, synonyms, functions, links).
+ * 4. Persist the consolidated dataset so the app can statically import it.
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+const FACETS_BASE_URL = 'https://world.openfoodfacts.org/facets/additives.json';
+const TAXONOMY_BASE_URL = 'https://world.openfoodfacts.org/api/v2/taxonomy?tagtype=additives&tags=';
+const OUTPUT_PATH = path.join(__dirname, '..', 'data', 'additives.json');
+const MAX_PAGE_CHECK = 10; // Guard to avoid infinite loops if the API changes.
+const REQUEST_DELAY_MS = 50; // Gentle delay between batch requests.
+const BATCH_SIZE = 10;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchJson(url, description) {
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync('curl', ['-fsS', url]);
+      return JSON.parse(stdout);
+    } catch (error) {
+      const isLastAttempt = attempt === 5;
+      console.error(
+        `Failed to fetch ${description} (attempt ${attempt}): ${error.message}`,
+      );
+      if (isLastAttempt) {
+        throw error;
+      }
+      await sleep(250 * attempt);
+    }
+  }
+
+  throw new Error(`Exhausted retries for ${description}`);
+}
+
+async function fetchAllAdditiveIds() {
+  const ids = new Set();
+  console.log('Fetching additive IDs from facets endpoint...');
+  for (let page = 1; page <= MAX_PAGE_CHECK; page += 1) {
+    const url = page === 1 ? FACETS_BASE_URL : `${FACETS_BASE_URL}?page=${page}`;
+    const data = await fetchJson(url, `facet page ${page}`);
+    if (!data.tags || data.tags.length === 0) {
+      console.log(`No tags returned for page ${page}; stopping.`);
+      break;
+    }
+
+    data.tags.forEach((tag) => {
+      if (tag && typeof tag.id === 'string') {
+        ids.add(tag.id);
+      }
+    });
+
+    console.log(` Page ${page}: collected ${data.tags.length} tags (total unique: ${ids.size}).`);
+
+    if (data.page && data.page.page === data.page.page_count) {
+      break;
+    }
+  }
+
+  console.log(`Finished fetching additive IDs. Total unique IDs: ${ids.size}.`);
+  return Array.from(ids);
+}
+
+function pickFirstString(value) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => (typeof item === 'string' ? item : null)).find(Boolean);
+  }
+
+  if (typeof value === 'object') {
+    const languages = ['en', 'fr', 'de', 'es'];
+    for (const lang of languages) {
+      if (Object.prototype.hasOwnProperty.call(value, lang)) {
+        const candidate = pickFirstString(value[lang]);
+        if (candidate) {
+          return candidate;
+        }
+      }
+    }
+
+    const entries = Object.values(value);
+    for (const entry of entries) {
+      const candidate = pickFirstString(entry);
+      if (candidate) {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function collectStringArray(value) {
+  if (!value) {
+    return [];
+  }
+
+  const collected = new Set();
+
+  const gather = (input) => {
+    if (!input) {
+      return;
+    }
+    if (typeof input === 'string') {
+      const trimmed = input.trim();
+      if (trimmed) {
+        collected.add(trimmed);
+      }
+      return;
+    }
+    if (Array.isArray(input)) {
+      input.forEach((item) => gather(item));
+      return;
+    }
+    if (typeof input === 'object') {
+      Object.values(input).forEach((item) => gather(item));
+    }
+  };
+
+  gather(value);
+  return Array.from(collected);
+}
+
+function normaliseFunctions(rawFunctions) {
+  const seen = new Set();
+
+  return collectStringArray(rawFunctions)
+    .flatMap((item) => item.split(/[,;]/))
+    .map((item) => item.trim())
+    .map((item) => item.replace(/^[a-z]{2,}:/i, '').trim())
+    .filter((item) => {
+      if (!item) {
+        return false;
+      }
+      const key = item.toLowerCase();
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+}
+
+function deriveENumber(id) {
+  const raw = typeof id === 'string' ? id.split(':').pop() : '';
+  if (!raw) {
+    return '';
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (!/^e\d+[a-z]*$/.test(normalized)) {
+    return '';
+  }
+  const withoutPrefix = normalized.replace(/^e/, '');
+  return `E${withoutPrefix.toUpperCase()}`;
+}
+
+function cleanseName(rawName) {
+  if (!rawName) {
+    return '';
+  }
+  const parts = rawName.split(' - ');
+  if (parts.length > 1) {
+    return parts.slice(1).join(' - ').trim();
+  }
+  return rawName.trim();
+}
+
+function sanitiseUrl(url) {
+  if (!url) {
+    return '';
+  }
+  return url.replace(/\s/g, '_');
+}
+
+function fallbackTitleFromId(id, eNumber) {
+  const rawSegment = typeof id === 'string' ? id.split(':').pop() : '';
+  if (!rawSegment) {
+    return eNumber || id;
+  }
+
+  const normalized = rawSegment.replace(/[_-]+/g, ' ').trim();
+  if (!normalized) {
+    return eNumber || rawSegment;
+  }
+
+  return normalized
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+async function fetchAdditiveDetails(id, index, total) {
+  const url = `${TAXONOMY_BASE_URL}${encodeURIComponent(id)}`;
+  const data = await fetchJson(url, `taxonomy for ${id}`);
+  const entry = data[id];
+  const eNumber = deriveENumber(id);
+
+  if (!entry) {
+    const fallbackTitle = fallbackTitleFromId(id, eNumber);
+    console.warn(` No taxonomy entry found for ${id}; using fallback metadata.`);
+    console.log(` Processed ${index}/${total}: ${id} -> ${fallbackTitle} (fallback)`);
+    return {
+      title: fallbackTitle,
+      eNumber,
+      synonyms: [],
+      functions: [],
+      description: '',
+      wikipedia: '',
+      wikidata: '',
+    };
+  }
+
+  let title = cleanseName(pickFirstString(entry.name)) || eNumber;
+  if (!title) {
+    title = fallbackTitleFromId(id, eNumber);
+  }
+  const synonyms = collectStringArray(entry.synonyms);
+  const functions = normaliseFunctions(entry.additives_classes);
+  const description = pickFirstString(entry.wikipedia_abstract) || '';
+  const wikipediaPreferred = pickFirstString(entry.wikipedia);
+  const wikipediaFallback = pickFirstString(entry.wikipedia_url);
+  const wikipedia = sanitiseUrl(wikipediaPreferred || wikipediaFallback || '');
+  const wikidata = pickFirstString(entry.wikidata) || '';
+
+  console.log(` Processed ${index}/${total}: ${id} -> ${title}`);
+
+  return {
+    title,
+    eNumber,
+    synonyms,
+    functions,
+    description,
+    wikipedia,
+    wikidata,
+  };
+}
+
+async function main() {
+  const ids = await fetchAllAdditiveIds();
+  const additives = [];
+
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const chunk = ids.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      chunk.map((id, offset) => fetchAdditiveDetails(id, i + offset + 1, ids.length)),
+    );
+    results
+      .filter((item) => item !== null)
+      .forEach((item) => additives.push(item));
+
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  additives.sort((a, b) => a.title.localeCompare(b.title, 'en'));
+
+  const payload = {
+    additives,
+  };
+
+  await fs.writeFile(OUTPUT_PATH, `${JSON.stringify(payload, null, 2)}\n`);
+  console.log(`Saved ${additives.length} additives to ${OUTPUT_PATH}`);
+}
+
+main().catch((error) => {
+  console.error('Failed to update additives dataset:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- refine the Open Food Facts exporter to split additive class strings, strip locale prefixes, and synthesize metadata when taxonomy records are missing so every facet entry is retained
- refresh the static dataset with the 630 additives from Open Food Facts, including cleaned function arrays and fallback items

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d72e17121883278579a36ba3dab8c6