### PR TITLE
Restore search interest summary on additive detail page

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { Box, Chip, Link as MuiLink, Stack, Typography } from '@mui/material';
 
 import { getAdditiveBySlug, getAdditiveSlugs } from '../../lib/additives';
+import { formatMonthlyVolume, getCountryFlagEmoji, getCountryLabel } from '../../lib/format';
 import { getSearchHistory } from '../../lib/search-history';
 import { SearchHistoryChart } from '../../components/SearchHistoryChart';
 
@@ -44,6 +45,13 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
   const synonymList = additive.synonyms.filter((value, index, list) => list.indexOf(value) === index);
   const searchHistory = getSearchHistory(additive.slug);
   const hasSearchHistory = !!searchHistory && searchHistory.metrics.length > 0;
+  const searchRank = typeof additive.searchRank === 'number' ? additive.searchRank : null;
+  const searchVolume = typeof additive.searchVolume === 'number' ? additive.searchVolume : null;
+  const searchCountryCode = searchHistory?.country;
+  const searchFlagEmoji = searchCountryCode ? getCountryFlagEmoji(searchCountryCode) : null;
+  const searchCountryLabel =
+    searchCountryCode && searchFlagEmoji ? getCountryLabel(searchCountryCode) ?? searchCountryCode.toUpperCase() : null;
+
   return (
     <Box component="article" display="flex" flexDirection="column" gap={4} alignItems="center" width="100%">
       <Box sx={{ width: '100%', maxWidth: 760, display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -74,6 +82,33 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
                   {synonym}
                 </Box>
               ))}
+            </Typography>
+          )}
+          {(searchRank !== null || searchVolume !== null || searchFlagEmoji) && (
+            <Typography variant="body1" color="text.secondary" sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Search interest:
+              </Box>
+              {searchRank !== null && (
+                <Box component="span" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                  #{searchRank}
+                </Box>
+              )}
+              {searchVolume !== null && (
+                <Box component="span" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                  {formatMonthlyVolume(searchVolume)} / mo
+                </Box>
+              )}
+              {searchFlagEmoji && (
+                <Box
+                  component="span"
+                  role="img"
+                  aria-label={searchCountryLabel ?? undefined}
+                  sx={{ fontSize: '1rem', lineHeight: 1 }}
+                >
+                  {searchFlagEmoji}
+                </Box>
+              )}
             </Typography>
           )}
         </Box>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from 
 
 import { getAdditives } from '../lib/additives';
 import { SearchSparkline } from '../components/SearchSparkline';
-import { formatMonthlySearchVolume } from '../lib/format';
+import { formatMonthlyVolume } from '../lib/format';
 
 const additives = getAdditives();
 
@@ -69,7 +69,7 @@ export default function HomePage() {
                         #{additive.searchRank}
                       </Typography>
                       <Typography component="span" variant="body2" color="text.secondary">
-                        {formatMonthlySearchVolume(additive.searchVolume!)} / mo
+                        {formatMonthlyVolume(additive.searchVolume!)} / mo
                       </Typography>
                     </Stack>
                   ) : (

--- a/components/SearchHistoryChart.tsx
+++ b/components/SearchHistoryChart.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react';
 import { ResponsiveLine } from '@nivo/line';
 import { Box, useTheme } from '@mui/material';
 
+import { formatMonthlyVolume } from '../lib/format';
+
 export interface SearchHistoryPoint {
   date: string;
   volume: number;
@@ -12,18 +14,6 @@ export interface SearchHistoryPoint {
 interface SearchHistoryChartProps {
   metrics: SearchHistoryPoint[];
 }
-
-const formatVolumeLabel = (value: number): string => {
-  if (value >= 1_000_000) {
-    return `${Math.round(value / 100_000) / 10}M`;
-  }
-
-  if (value >= 1_000) {
-    return `${Math.round(value / 100) / 10}K`;
-  }
-
-  return `${Math.round(value)}`;
-};
 
 export function SearchHistoryChart({ metrics }: SearchHistoryChartProps) {
   const theme = useTheme();
@@ -58,7 +48,7 @@ export function SearchHistoryChart({ metrics }: SearchHistoryChartProps) {
         axisLeft={{
           tickSize: 6,
           tickPadding: 8,
-          format: (value) => formatVolumeLabel(Number(value)),
+          format: (value) => formatMonthlyVolume(Number(value)),
         }}
         theme={{
           axis: {
@@ -115,7 +105,7 @@ export function SearchHistoryChart({ metrics }: SearchHistoryChartProps) {
                   })}
                 </Box>
                 <Box component="span" sx={{ fontSize: 14, fontWeight: 600 }}>
-                  {formatVolumeLabel(point.data.y as number)} / mo
+                  {formatMonthlyVolume(point.data.y as number)} / mo
                 </Box>
               </Box>
             ))}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,7 +1,52 @@
-const compactNumberFormatter = new Intl.NumberFormat('en-US', {
-  notation: 'compact',
-  maximumFractionDigits: 1,
-});
+export const formatMonthlyVolume = (value: number): string => {
+  if (!Number.isFinite(value)) {
+    return '';
+  }
 
-export const formatMonthlySearchVolume = (value: number): string =>
-  compactNumberFormatter.format(value);
+  if (value >= 1_000_000) {
+    return `${Math.round(value / 100_000) / 10}M`;
+  }
+
+  if (value >= 1_000) {
+    return `${Math.round(value / 100) / 10}K`;
+  }
+
+  return `${Math.round(value)}`;
+};
+
+const COUNTRY_NAME_MAP: Record<string, string> = {
+  US: 'United States',
+};
+
+const getCountryDisplayName = (countryCode: string): string | null => {
+  const code = countryCode.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(code)) {
+    return null;
+  }
+
+  if (COUNTRY_NAME_MAP[code]) {
+    return COUNTRY_NAME_MAP[code];
+  }
+
+  if (typeof Intl !== 'undefined' && typeof Intl.DisplayNames !== 'undefined') {
+    const displayNames = new Intl.DisplayNames(['en'], { type: 'region' });
+    const name = displayNames.of(code);
+    if (name) {
+      return name;
+    }
+  }
+
+  return code;
+};
+
+export const getCountryFlagEmoji = (countryCode: string): string | null => {
+  const code = countryCode.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(code)) {
+    return null;
+  }
+
+  const codePoints = Array.from(code).map((char) => 0x1f1e6 + char.charCodeAt(0) - 65);
+  return String.fromCodePoint(...codePoints);
+};
+
+export const getCountryLabel = (countryCode: string): string | null => getCountryDisplayName(countryCode);


### PR DESCRIPTION
## Summary
- restore the search interest summary on additive detail pages with rank, volume, and country flag details
- centralize the monthly volume formatter and expose helpers for rendering country names and flags
- reuse the shared formatter in the search history chart and home page cards

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d897f77d488327a43a629b271bac91