### PR TITLE
Use OpenAI SDK for additive article generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
         "next": "^15.5.4",
+        "openai": "^6.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
@@ -6498,6 +6499,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.1.0.tgz",
+      "integrity": "sha512-5sqb1wK67HoVgGlsPwcH2bUbkg66nnoIYKoyV9zi5pZPqh7EWlmSrSDjAh4O5jaIg/0rIlcDKBtWvZBuacmGZg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nivo/core": "^0.99.0",
     "@nivo/line": "^0.99.0",
     "next": "^15.5.4",
+    "openai": "^6.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",

--- a/scripts/prompts/additive-article.txt
+++ b/scripts/prompts/additive-article.txt
@@ -1,5 +1,5 @@
 ROLE
-You are a content generator for a public-facing website about food additives. Your job is to produce (a) a ready-to-publish Markdown article and (b) article summary in textual format.
+You are a content generator for a public-facing website about food additives. Your job is to produce a ready-to-publish Markdown article.
 
 AUDIENCE & STYLE
 - U.S. shoppers and home cooks.
@@ -25,10 +25,11 @@ TERMS GUARDRAIL
 - Avoid: unsullied, sulphites (unless noting UK/EU spelling), "fresh dried fruit".
 
 OUTPUT
-Return A Markdown article and textual summary
+Return a Markdown article
 
 ARTICLE LAYOUT
-- Heading: "<E-number> — <Common name or additive name>"
+- Summary (plain text, 2-3 sentences)
+- Separator <!--more-->, which separates summary from main article
 - "At a glance" bullets (also-called/E-number, what it does, common in, diet flags)
 - 1) Why it's added to food
 - 2) What foods it's found in


### PR DESCRIPTION
## Summary
- integrate the official OpenAI Node SDK to hit the gpt-5 responses endpoint with high reasoning effort and JSON schema parsing in the article generator
- keep the article prompt external, default to processing 10 additives at a time, and enhance progress/error messaging while skipping existing files
- add the openai dependency required by the script

## Testing
- npm run lint
- CI=1 npm run build
- node scripts/generate-articles.js *(fails: OpenAI connection error in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0a9b2c8cc8327b913ce477c2f57eb