### PR TITLE
Redesign additive grid cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,24 @@
 import Link from 'next/link';
-import { Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
+import { Avatar, Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
 
 import { getAdditives } from '../lib/additives';
 import { SearchSparkline } from '../components/SearchSparkline';
 import { formatMonthlyVolume } from '../lib/format';
 
 const additives = getAdditives();
+
+const getOriginLabel = (origin: string) => {
+  const letters = origin.replace(/[^A-Za-z]/g, '');
+
+  if (letters.length === 0) {
+    return '';
+  }
+
+  const first = letters.charAt(0).toUpperCase();
+  const second = letters.charAt(1);
+
+  return `${first}${second ? second.toLowerCase() : ''}`;
+};
 
 export default function HomePage() {
   return (
@@ -41,56 +54,91 @@ export default function HomePage() {
             additive.searchSparkline.some((value) => value !== null);
           const hasSearchMetrics =
             typeof additive.searchRank === 'number' && typeof additive.searchVolume === 'number';
+          const showSearchSection = hasSparkline || hasSearchMetrics;
+          const visibleFunctions = additive.functions.slice(0, 2);
+          const hiddenFunctionCount = Math.max(additive.functions.length - visibleFunctions.length, 0);
+          const origins = additive.origin.filter((origin) => origin.trim().length > 0);
 
           return (
             <Card key={additive.slug} sx={{ display: 'flex', flexDirection: 'column' }}>
               <CardActionArea component={Link} href={`/${additive.slug}`} sx={{ flexGrow: 1 }}>
-                <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  <Box display="flex" flexDirection="column" gap={0.5}>
+                <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                  <Box display="flex" justifyContent="space-between" alignItems="flex-start">
                     <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
                       {additive.eNumber}
                     </Typography>
-                    <Typography component="h2" variant="h2">
-                      {additive.title}
-                    </Typography>
+                    {origins.length > 0 ? (
+                      <Stack direction="row" spacing={0.5}>
+                        {origins.map((origin) => {
+                          const label = getOriginLabel(origin);
+
+                          return (
+                            <Avatar
+                              key={origin}
+                              variant="circular"
+                              sx={{
+                                width: 28,
+                                height: 28,
+                                bgcolor: 'grey.100',
+                                color: 'text.primary',
+                                fontSize: 12,
+                                fontWeight: 600,
+                              }}
+                            >
+                              {label}
+                            </Avatar>
+                          );
+                        })}
+                      </Stack>
+                    ) : (
+                      <Box sx={{ minHeight: 28 }} />
+                    )}
                   </Box>
-                  {additive.functions.length > 0 ? (
-                    <Stack direction="row" flexWrap="wrap" gap={1}>
-                      {additive.functions.map((fn) => (
-                        <Chip key={fn} label={fn} variant="outlined" />
+
+                  <Typography component="h2" variant="h2">
+                    {additive.title}
+                  </Typography>
+
+                  {visibleFunctions.length > 0 ? (
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'nowrap' }}>
+                      {visibleFunctions.map((fn) => (
+                        <Chip key={fn} label={fn} variant="outlined" size="small" />
                       ))}
+                      {hiddenFunctionCount > 0 && (
+                        <Chip label={`(+${hiddenFunctionCount})`} variant="outlined" size="small" />
+                      )}
                     </Stack>
                   ) : (
-                    <Box sx={{ minHeight: '1.5rem' }} />
+                    <Box sx={{ minHeight: 24 }} />
                   )}
-                  {hasSearchMetrics ? (
-                    <Stack direction="row" alignItems="baseline" gap={1}>
-                      <Typography component="span" variant="subtitle1" fontWeight={600}>
-                        #{additive.searchRank}
-                      </Typography>
-                      <Typography component="span" variant="body2" color="text.secondary">
-                        {formatMonthlyVolume(additive.searchVolume!)} / mo
-                      </Typography>
+
+                  {showSearchSection ? (
+                    <Stack direction="row" alignItems="center" spacing={1.5}>
+                      {hasSearchMetrics ? (
+                        <Stack direction="row" alignItems="baseline" spacing={1} flexShrink={0}>
+                          <Typography component="span" variant="subtitle1" fontWeight={600}>
+                            #{additive.searchRank}
+                          </Typography>
+                          <Typography component="span" variant="body2" color="text.secondary">
+                            {formatMonthlyVolume(additive.searchVolume!)} / mo
+                          </Typography>
+                        </Stack>
+                      ) : (
+                        <Box sx={{ minWidth: 0 }} />
+                      )}
+                      {hasSparkline ? (
+                        <Box sx={{ flexGrow: 1, minWidth: 96 }}>
+                          <SearchSparkline values={additive.searchSparkline ?? []} />
+                        </Box>
+                      ) : (
+                        <Box sx={{ flexGrow: 1, height: 40 }} />
+                      )}
                     </Stack>
                   ) : (
-                    <Box sx={{ minHeight: '1.5rem' }} />
+                    <Box sx={{ height: 40 }} />
                   )}
                 </CardContent>
               </CardActionArea>
-              {hasSparkline && (
-                <Box
-                  component={Link}
-                  href={`/${additive.slug}#search-history`}
-                  sx={{
-                    px: 2,
-                    pb: 1.5,
-                    pt: 1,
-                    display: 'block',
-                  }}
-                >
-                  <SearchSparkline values={additive.searchSparkline ?? []} />
-                </Box>
-              )}
             </Card>
           );
         })}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
 import { Avatar, Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
 
 import { getAdditives } from '../lib/additives';
 import { SearchSparkline } from '../components/SearchSparkline';
 import { formatMonthlyVolume } from '../lib/format';
+import { theme } from '../lib/theme';
 
 const additives = getAdditives();
 
@@ -19,6 +21,46 @@ const getOriginLabel = (origin: string) => {
 
   return `${first}${second ? second.toLowerCase() : ''}`;
 };
+
+const getTitleMinHeight = (theme: Theme) => {
+  const toRem = (value: string | number) => {
+    if (typeof value === 'number') {
+      return value / theme.typography.htmlFontSize;
+    }
+
+    if (value.endsWith('rem')) {
+      return parseFloat(value);
+    }
+
+    if (value.endsWith('px')) {
+      return parseFloat(value) / theme.typography.htmlFontSize;
+    }
+
+    return parseFloat(value);
+  };
+
+  const parseLineHeight = (value: string | number) => {
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    if (value.endsWith('%')) {
+      return parseFloat(value) / 100;
+    }
+
+    return parseFloat(value);
+  };
+
+  const fontSize = toRem(theme.typography.h2.fontSize ?? 0);
+  const lineHeight = parseLineHeight(theme.typography.h2.lineHeight ?? 0);
+
+  const safeFontSize = Number.isFinite(fontSize) && fontSize > 0 ? fontSize : 1;
+  const safeLineHeight = Number.isFinite(lineHeight) && lineHeight > 0 ? lineHeight : 1.2;
+
+  return `${safeFontSize * safeLineHeight * 2}rem`;
+};
+
+const titleMinHeight = getTitleMinHeight(theme);
 
 export default function HomePage() {
   return (
@@ -61,59 +103,80 @@ export default function HomePage() {
 
           return (
             <Card key={additive.slug} sx={{ display: 'flex', flexDirection: 'column' }}>
-              <CardActionArea component={Link} href={`/${additive.slug}`} sx={{ flexGrow: 1 }}>
-                <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-                  <Box display="flex" justifyContent="space-between" alignItems="flex-start">
-                    <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
-                      {additive.eNumber}
-                    </Typography>
-                    {origins.length > 0 ? (
-                      <Stack direction="row" spacing={0.5}>
-                        {origins.map((origin) => {
-                          const label = getOriginLabel(origin);
+              <CardActionArea
+                component={Link}
+                href={`/${additive.slug}`}
+                sx={{ flexGrow: 1, display: 'flex', alignItems: 'stretch' }}
+              >
+                <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                  <Stack spacing={1.5} sx={{ flexGrow: 1 }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="flex-start">
+                      <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
+                        {additive.eNumber}
+                      </Typography>
+                      {origins.length > 0 ? (
+                        <Stack direction="row" spacing={0.5}>
+                          {origins.map((origin) => {
+                            const label = getOriginLabel(origin);
 
-                          return (
-                            <Avatar
-                              key={origin}
-                              variant="circular"
-                              sx={{
-                                width: 28,
-                                height: 28,
-                                bgcolor: 'grey.100',
-                                color: 'text.primary',
-                                fontSize: 12,
-                                fontWeight: 600,
-                              }}
-                            >
-                              {label}
-                            </Avatar>
-                          );
-                        })}
+                            return (
+                              <Avatar
+                                key={origin}
+                                variant="circular"
+                                sx={{
+                                  width: 28,
+                                  height: 28,
+                                  bgcolor: 'grey.100',
+                                  color: 'text.primary',
+                                  fontSize: 12,
+                                  fontWeight: 600,
+                                }}
+                              >
+                                {label}
+                              </Avatar>
+                            );
+                          })}
+                        </Stack>
+                      ) : (
+                        <Box sx={{ minHeight: 28, minWidth: 28 }} />
+                      )}
+                    </Box>
+
+                    <Typography
+                      component="h2"
+                      variant="h2"
+                      sx={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                        minHeight: titleMinHeight,
+                      }}
+                    >
+                      {additive.title}
+                    </Typography>
+
+                    {visibleFunctions.length > 0 ? (
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        alignItems="center"
+                        sx={{ flexWrap: 'nowrap', minHeight: 28 }}
+                      >
+                        {visibleFunctions.map((fn) => (
+                          <Chip key={fn} label={fn} variant="outlined" size="small" />
+                        ))}
+                        {hiddenFunctionCount > 0 && (
+                          <Chip label={`+${hiddenFunctionCount}`} variant="outlined" size="small" />
+                        )}
                       </Stack>
                     ) : (
                       <Box sx={{ minHeight: 28 }} />
                     )}
-                  </Box>
-
-                  <Typography component="h2" variant="h2">
-                    {additive.title}
-                  </Typography>
-
-                  {visibleFunctions.length > 0 ? (
-                    <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'nowrap' }}>
-                      {visibleFunctions.map((fn) => (
-                        <Chip key={fn} label={fn} variant="outlined" size="small" />
-                      ))}
-                      {hiddenFunctionCount > 0 && (
-                        <Chip label={`(+${hiddenFunctionCount})`} variant="outlined" size="small" />
-                      )}
-                    </Stack>
-                  ) : (
-                    <Box sx={{ minHeight: 24 }} />
-                  )}
+                  </Stack>
 
                   {showSearchSection ? (
-                    <Stack direction="row" alignItems="center" spacing={1.5}>
+                    <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mt: 1.5 }}>
                       {hasSearchMetrics ? (
                         <Stack direction="row" alignItems="baseline" spacing={1} flexShrink={0}>
                           <Typography component="span" variant="subtitle1" fontWeight={600}>
@@ -135,7 +198,7 @@ export default function HomePage() {
                       )}
                     </Stack>
                   ) : (
-                    <Box sx={{ height: 40 }} />
+                    <Box sx={{ height: 40, mt: 1.5 }} />
                   )}
                 </CardContent>
               </CardActionArea>


### PR DESCRIPTION
## Summary
- update additive grid cards to display E-numbers and origin badges in the header
- limit function pills to a single line with overflow counts and align search metrics in one row
- integrate the sparkline beside rank and volume to match the redesigned layout

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2f2c93f4483279c1429fe2c260976