### PR TITLE
Add filter pages for additive functions and origins

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from 'next';
+import NextLink from 'next/link';
 import { notFound } from 'next/navigation';
 import { Box, Chip, Link as MuiLink, Stack, Typography } from '@mui/material';
 
-import { getAdditiveBySlug, getAdditiveSlugs } from '../../lib/additives';
+import {
+  getAdditiveBySlug,
+  getAdditiveSlugs,
+  getFunctionSlug,
+  getOriginSlug,
+} from '../../lib/additives';
 import { formatMonthlyVolume, getCountryFlagEmoji, getCountryLabel } from '../../lib/format';
 import { getSearchHistory } from '../../lib/search-history';
 import { SearchHistoryChart } from '../../components/SearchHistoryChart';
@@ -181,9 +187,24 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
             >
               Function:
             </Typography>
-            {additive.functions.map((fn) => (
-              <Chip key={fn} label={fn} variant="outlined" />
-            ))}
+            {additive.functions.map((fn) => {
+              const functionSlug = getFunctionSlug(fn);
+
+              if (!functionSlug) {
+                return <Chip key={fn} label={fn} variant="outlined" />;
+              }
+
+              return (
+                <Chip
+                  key={fn}
+                  label={fn}
+                  variant="outlined"
+                  component={NextLink}
+                  href={`/function/${functionSlug}`}
+                  clickable
+                />
+              );
+            })}
           </Stack>
         )}
 
@@ -196,9 +217,25 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
             >
               Origin:
             </Typography>
-            {originList.map((origin) => (
-              <Chip key={origin} label={formatOriginLabel(origin)} variant="outlined" />
-            ))}
+            {originList.map((origin) => {
+              const originSlug = getOriginSlug(origin);
+              const label = formatOriginLabel(origin);
+
+              if (!originSlug) {
+                return <Chip key={origin} label={label} variant="outlined" />;
+              }
+
+              return (
+                <Chip
+                  key={origin}
+                  label={label}
+                  variant="outlined"
+                  component={NextLink}
+                  href={`/origin/${originSlug}`}
+                  clickable
+                />
+              );
+            })}
           </Stack>
         )}
 

--- a/app/function/[functionSlug]/page.tsx
+++ b/app/function/[functionSlug]/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { Box, Typography } from '@mui/material';
+
+import {
+  getAdditivesByFunctionSlug,
+  getFunctionFilters,
+  getFunctionValueBySlug,
+} from '../../../lib/additives';
+import { formatFilterLabel } from '../../../lib/text';
+import { AdditiveGrid } from '../../../components/AdditiveGrid';
+
+interface FunctionPageProps {
+  params: Promise<{ functionSlug: string }>;
+}
+
+const formatCountLabel = (count: number): string =>
+  count === 1 ? '1 additive uses this function.' : `${count} additives use this function.`;
+
+export async function generateStaticParams() {
+  return getFunctionFilters().map(({ slug }) => ({ functionSlug: slug }));
+}
+
+export async function generateMetadata({ params }: FunctionPageProps): Promise<Metadata> {
+  const { functionSlug } = await params;
+  const functionValue = getFunctionValueBySlug(functionSlug);
+
+  if (!functionValue) {
+    return {
+      title: 'Function not found',
+    };
+  }
+
+  const label = formatFilterLabel(functionValue);
+
+  return {
+    title: `${label} food additives`,
+    description: `Browse food additives that function as ${functionValue}.`,
+    alternates: {
+      canonical: `/function/${functionSlug}`,
+    },
+  };
+}
+
+export default async function FunctionPage({ params }: FunctionPageProps) {
+  const { functionSlug } = await params;
+  const functionValue = getFunctionValueBySlug(functionSlug);
+
+  if (!functionValue) {
+    notFound();
+  }
+
+  const additives = getAdditivesByFunctionSlug(functionSlug);
+  const label = formatFilterLabel(functionValue);
+
+  return (
+    <Box component="section" display="flex" flexDirection="column" gap={4}>
+      <Box display="flex" flexDirection="column" gap={1.5} maxWidth={720}>
+        <Typography component="h1" variant="h1">
+          Function: {label}
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          {formatCountLabel(additives.length)}
+        </Typography>
+      </Box>
+
+      <AdditiveGrid items={additives} emptyMessage="No additives found for this function." />
+    </Box>
+  );
+}

--- a/app/function/[functionSlug]/page.tsx
+++ b/app/function/[functionSlug]/page.tsx
@@ -5,10 +5,12 @@ import { Box, Typography } from '@mui/material';
 import {
   getAdditivesByFunctionSlug,
   getFunctionFilters,
+  getOriginFilters,
   getFunctionValueBySlug,
 } from '../../../lib/additives';
 import { formatFilterLabel } from '../../../lib/text';
 import { AdditiveGrid } from '../../../components/AdditiveGrid';
+import { FilterPanel } from '../../../components/FilterPanel';
 
 interface FunctionPageProps {
   params: Promise<{ functionSlug: string }>;
@@ -17,8 +19,20 @@ interface FunctionPageProps {
 const formatCountLabel = (count: number): string =>
   count === 1 ? '1 additive uses this function.' : `${count} additives use this function.`;
 
+const functionFilters = getFunctionFilters();
+const originFilters = getOriginFilters();
+
+const functionOptions = functionFilters.map(({ slug, value }) => ({
+  slug,
+  label: formatFilterLabel(value),
+}));
+const originOptions = originFilters.map(({ slug, value }) => ({
+  slug,
+  label: formatFilterLabel(value),
+}));
+
 export async function generateStaticParams() {
-  return getFunctionFilters().map(({ slug }) => ({ functionSlug: slug }));
+  return functionFilters.map(({ slug }) => ({ functionSlug: slug }));
 }
 
 export async function generateMetadata({ params }: FunctionPageProps): Promise<Metadata> {
@@ -64,6 +78,11 @@ export default async function FunctionPage({ params }: FunctionPageProps) {
         </Typography>
       </Box>
 
+      <FilterPanel
+        functionOptions={functionOptions}
+        originOptions={originOptions}
+        currentFunctionSlug={functionSlug}
+      />
       <AdditiveGrid items={additives} emptyMessage="No additives found for this function." />
     </Box>
   );

--- a/app/origin/[originSlug]/page.tsx
+++ b/app/origin/[originSlug]/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { Box, Typography } from '@mui/material';
+
+import {
+  getAdditivesByOriginSlug,
+  getOriginFilters,
+  getOriginValueBySlug,
+} from '../../../lib/additives';
+import { formatFilterLabel } from '../../../lib/text';
+import { AdditiveGrid } from '../../../components/AdditiveGrid';
+
+interface OriginPageProps {
+  params: Promise<{ originSlug: string }>;
+}
+
+const formatCountLabel = (count: number): string =>
+  count === 1 ? '1 additive has this origin.' : `${count} additives have this origin.`;
+
+export async function generateStaticParams() {
+  return getOriginFilters().map(({ slug }) => ({ originSlug: slug }));
+}
+
+export async function generateMetadata({ params }: OriginPageProps): Promise<Metadata> {
+  const { originSlug } = await params;
+  const originValue = getOriginValueBySlug(originSlug);
+
+  if (!originValue) {
+    return {
+      title: 'Origin not found',
+    };
+  }
+
+  const label = formatFilterLabel(originValue);
+
+  return {
+    title: `${label} origin additives`,
+    description: `Explore food additives that originate from ${originValue}.`,
+    alternates: {
+      canonical: `/origin/${originSlug}`,
+    },
+  };
+}
+
+export default async function OriginPage({ params }: OriginPageProps) {
+  const { originSlug } = await params;
+  const originValue = getOriginValueBySlug(originSlug);
+
+  if (!originValue) {
+    notFound();
+  }
+
+  const additives = getAdditivesByOriginSlug(originSlug);
+  const label = formatFilterLabel(originValue);
+
+  return (
+    <Box component="section" display="flex" flexDirection="column" gap={4}>
+      <Box display="flex" flexDirection="column" gap={1.5} maxWidth={720}>
+        <Typography component="h1" variant="h1">
+          Origin: {label}
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          {formatCountLabel(additives.length)}
+        </Typography>
+      </Box>
+
+      <AdditiveGrid items={additives} emptyMessage="No additives found for this origin." />
+    </Box>
+  );
+}

--- a/app/origin/[originSlug]/page.tsx
+++ b/app/origin/[originSlug]/page.tsx
@@ -4,11 +4,13 @@ import { Box, Typography } from '@mui/material';
 
 import {
   getAdditivesByOriginSlug,
+  getFunctionFilters,
   getOriginFilters,
   getOriginValueBySlug,
 } from '../../../lib/additives';
 import { formatFilterLabel } from '../../../lib/text';
 import { AdditiveGrid } from '../../../components/AdditiveGrid';
+import { FilterPanel } from '../../../components/FilterPanel';
 
 interface OriginPageProps {
   params: Promise<{ originSlug: string }>;
@@ -17,8 +19,20 @@ interface OriginPageProps {
 const formatCountLabel = (count: number): string =>
   count === 1 ? '1 additive has this origin.' : `${count} additives have this origin.`;
 
+const originFilters = getOriginFilters();
+const functionFilters = getFunctionFilters();
+
+const originOptions = originFilters.map(({ slug, value }) => ({
+  slug,
+  label: formatFilterLabel(value),
+}));
+const functionOptions = functionFilters.map(({ slug, value }) => ({
+  slug,
+  label: formatFilterLabel(value),
+}));
+
 export async function generateStaticParams() {
-  return getOriginFilters().map(({ slug }) => ({ originSlug: slug }));
+  return originFilters.map(({ slug }) => ({ originSlug: slug }));
 }
 
 export async function generateMetadata({ params }: OriginPageProps): Promise<Metadata> {
@@ -64,6 +78,11 @@ export default async function OriginPage({ params }: OriginPageProps) {
         </Typography>
       </Box>
 
+      <FilterPanel
+        functionOptions={functionOptions}
+        originOptions={originOptions}
+        currentOriginSlug={originSlug}
+      />
       <AdditiveGrid items={additives} emptyMessage="No additives found for this origin." />
     </Box>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,23 @@
-import { Box, Typography } from '@mui/material';
-
-import { getAdditives, getFunctionFilters, getOriginFilters } from '../lib/additives';
-import { AdditiveGrid } from '../components/AdditiveGrid';
-import { FilterPanel } from '../components/FilterPanel';
-import { formatFilterLabel } from '../lib/text';
 import Link from 'next/link';
-import { Avatar, Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  Stack,
+  Typography,
+} from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 
-import { getAdditives } from '../lib/additives';
+import { AdditiveGrid } from '../components/AdditiveGrid';
+import { FilterPanel } from '../components/FilterPanel';
 import { SearchSparkline } from '../components/SearchSparkline';
+import { getAdditives, getFunctionFilters, getOriginFilters } from '../lib/additives';
 import { formatMonthlyVolume } from '../lib/format';
 import { theme } from '../lib/theme';
+import { formatFilterLabel } from '../lib/text';
 
 const additives = getAdditives();
 const functionOptions = getFunctionFilters().map(({ slug, value }) => ({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,7 @@
-import Link from 'next/link';
-import { Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import { getAdditives } from '../lib/additives';
-import { SearchSparkline } from '../components/SearchSparkline';
-import { formatMonthlyVolume } from '../lib/format';
+import { AdditiveGrid } from '../components/AdditiveGrid';
 
 const additives = getAdditives();
 
@@ -20,81 +18,7 @@ export default function HomePage() {
         </Typography>
       </Box>
 
-      <Box
-        display="grid"
-        gap={{ xs: 2, sm: 3 }}
-        sx={{
-          gridTemplateColumns: {
-            xs: '1fr',
-            sm: 'repeat(2, 1fr)',
-            md: 'repeat(3, 1fr)',
-            lg: 'repeat(4, 1fr)',
-          },
-          '@media (min-width: 1600px)': {
-            gridTemplateColumns: 'repeat(6, 1fr)',
-          },
-        }}
-      >
-        {additives.map((additive) => {
-          const hasSparkline =
-            Array.isArray(additive.searchSparkline) &&
-            additive.searchSparkline.some((value) => value !== null);
-          const hasSearchMetrics =
-            typeof additive.searchRank === 'number' && typeof additive.searchVolume === 'number';
-
-          return (
-            <Card key={additive.slug} sx={{ display: 'flex', flexDirection: 'column' }}>
-              <CardActionArea component={Link} href={`/${additive.slug}`} sx={{ flexGrow: 1 }}>
-                <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  <Box display="flex" flexDirection="column" gap={0.5}>
-                    <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
-                      {additive.eNumber}
-                    </Typography>
-                    <Typography component="h2" variant="h2">
-                      {additive.title}
-                    </Typography>
-                  </Box>
-                  {additive.functions.length > 0 ? (
-                    <Stack direction="row" flexWrap="wrap" gap={1}>
-                      {additive.functions.map((fn) => (
-                        <Chip key={fn} label={fn} variant="outlined" />
-                      ))}
-                    </Stack>
-                  ) : (
-                    <Box sx={{ minHeight: '1.5rem' }} />
-                  )}
-                  {hasSearchMetrics ? (
-                    <Stack direction="row" alignItems="baseline" gap={1}>
-                      <Typography component="span" variant="subtitle1" fontWeight={600}>
-                        #{additive.searchRank}
-                      </Typography>
-                      <Typography component="span" variant="body2" color="text.secondary">
-                        {formatMonthlyVolume(additive.searchVolume!)} / mo
-                      </Typography>
-                    </Stack>
-                  ) : (
-                    <Box sx={{ minHeight: '1.5rem' }} />
-                  )}
-                </CardContent>
-              </CardActionArea>
-              {hasSparkline && (
-                <Box
-                  component={Link}
-                  href={`/${additive.slug}#search-history`}
-                  sx={{
-                    px: 2,
-                    pb: 1.5,
-                    pt: 1,
-                    display: 'block',
-                  }}
-                >
-                  <SearchSparkline values={additive.searchSparkline ?? []} />
-                </Box>
-              )}
-            </Card>
-          );
-        })}
-      </Box>
+      <AdditiveGrid items={additives} />
     </Box>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,19 @@
 import { Box, Typography } from '@mui/material';
 
-import { getAdditives } from '../lib/additives';
+import { getAdditives, getFunctionFilters, getOriginFilters } from '../lib/additives';
 import { AdditiveGrid } from '../components/AdditiveGrid';
+import { FilterPanel } from '../components/FilterPanel';
+import { formatFilterLabel } from '../lib/text';
 
 const additives = getAdditives();
+const functionOptions = getFunctionFilters().map(({ slug, value }) => ({
+  slug,
+  label: formatFilterLabel(value),
+}));
+const originOptions = getOriginFilters().map(({ slug, value }) => ({
+  slug,
+  label: formatFilterLabel(value),
+}));
 
 export default function HomePage() {
   return (
@@ -18,6 +28,7 @@ export default function HomePage() {
         </Typography>
       </Box>
 
+      <FilterPanel functionOptions={functionOptions} originOptions={originOptions} />
       <AdditiveGrid items={additives} />
     </Box>
   );

--- a/components/AdditiveGrid.tsx
+++ b/components/AdditiveGrid.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import { Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
+
+import type { Additive } from '../lib/additives';
+import { formatMonthlyVolume } from '../lib/format';
+import { SearchSparkline } from './SearchSparkline';
+
+interface AdditiveGridProps {
+  items: Additive[];
+  emptyMessage?: string;
+}
+
+export function AdditiveGrid({ items, emptyMessage = 'No additives found.' }: AdditiveGridProps) {
+  if (items.length === 0) {
+    return (
+      <Typography variant="body1" color="text.secondary">
+        {emptyMessage}
+      </Typography>
+    );
+  }
+
+  return (
+    <Box
+      display="grid"
+      gap={{ xs: 2, sm: 3 }}
+      sx={{
+        gridTemplateColumns: {
+          xs: '1fr',
+          sm: 'repeat(2, 1fr)',
+          md: 'repeat(3, 1fr)',
+          lg: 'repeat(4, 1fr)',
+        },
+        '@media (min-width: 1600px)': {
+          gridTemplateColumns: 'repeat(6, 1fr)',
+        },
+      }}
+    >
+      {items.map((additive) => {
+        const hasSparkline =
+          Array.isArray(additive.searchSparkline) &&
+          additive.searchSparkline.some((value) => value !== null);
+        const hasSearchMetrics =
+          typeof additive.searchRank === 'number' && typeof additive.searchVolume === 'number';
+
+        return (
+          <Card key={additive.slug} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <CardActionArea component={Link} href={`/${additive.slug}`} sx={{ flexGrow: 1 }}>
+              <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Box display="flex" flexDirection="column" gap={0.5}>
+                  <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
+                    {additive.eNumber}
+                  </Typography>
+                  <Typography component="h2" variant="h2">
+                    {additive.title}
+                  </Typography>
+                </Box>
+                {additive.functions.length > 0 ? (
+                  <Stack direction="row" flexWrap="wrap" gap={1}>
+                    {additive.functions.map((fn) => (
+                      <Chip key={fn} label={fn} variant="outlined" />
+                    ))}
+                  </Stack>
+                ) : (
+                  <Box sx={{ minHeight: '1.5rem' }} />
+                )}
+                {hasSearchMetrics ? (
+                  <Stack direction="row" alignItems="baseline" gap={1}>
+                    <Typography component="span" variant="subtitle1" fontWeight={600}>
+                      #{additive.searchRank}
+                    </Typography>
+                    <Typography component="span" variant="body2" color="text.secondary">
+                      {formatMonthlyVolume(additive.searchVolume!)} / mo
+                    </Typography>
+                  </Stack>
+                ) : (
+                  <Box sx={{ minHeight: '1.5rem' }} />
+                )}
+              </CardContent>
+            </CardActionArea>
+            {hasSparkline && (
+              <Box
+                component={Link}
+                href={`/${additive.slug}#search-history`}
+                sx={{
+                  px: 2,
+                  pb: 1.5,
+                  pt: 1,
+                  display: 'block',
+                }}
+              >
+                <SearchSparkline values={additive.searchSparkline ?? []} />
+              </Box>
+            )}
+          </Card>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/FilterPanel.tsx
+++ b/components/FilterPanel.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+
+export interface FilterOption {
+  slug: string;
+  label: string;
+}
+
+interface FilterPanelProps {
+  functionOptions: FilterOption[];
+  originOptions: FilterOption[];
+  currentFunctionSlug?: string | null;
+  currentOriginSlug?: string | null;
+}
+
+const HOME_ROUTE = '/';
+
+export function FilterPanel({
+  functionOptions,
+  originOptions,
+  currentFunctionSlug = null,
+  currentOriginSlug = null,
+}: FilterPanelProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const handleFunctionChange = (event: SelectChangeEvent<string>) => {
+    const slug = event.target.value;
+
+    startTransition(() => {
+      if (slug) {
+        router.push(`/function/${slug}`);
+      } else {
+        router.push(HOME_ROUTE);
+      }
+    });
+  };
+
+  const handleOriginChange = (event: SelectChangeEvent<string>) => {
+    const slug = event.target.value;
+
+    startTransition(() => {
+      if (slug) {
+        router.push(`/origin/${slug}`);
+      } else {
+        router.push(HOME_ROUTE);
+      }
+    });
+  };
+
+  return (
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      justifyContent={{ xs: 'flex-start', sm: 'flex-end' }}
+      alignItems={{ xs: 'stretch', sm: 'center' }}
+      spacing={1.5}
+      width="100%"
+      flexWrap="wrap"
+    >
+      <FormControl
+        size="small"
+        sx={{ minWidth: { xs: '100%', sm: 180 } }}
+        disabled={isPending}
+      >
+        <InputLabel id="origin-filter-label">Origin</InputLabel>
+        <Select
+          labelId="origin-filter-label"
+          id="origin-filter"
+          label="Origin"
+          value={currentOriginSlug ?? ''}
+          onChange={handleOriginChange}
+        >
+          <MenuItem value="">All origins</MenuItem>
+          {originOptions.map((option) => (
+            <MenuItem key={option.slug} value={option.slug}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl
+        size="small"
+        sx={{ minWidth: { xs: '100%', sm: 180 } }}
+        disabled={isPending}
+      >
+        <InputLabel id="function-filter-label">Function</InputLabel>
+        <Select
+          labelId="function-filter-label"
+          id="function-filter"
+          label="Function"
+          value={currentFunctionSlug ?? ''}
+          onChange={handleFunctionChange}
+        >
+          <MenuItem value="">All functions</MenuItem>
+          {functionOptions.map((option) => (
+            <MenuItem key={option.slug} value={option.slug}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Stack>
+  );
+}

--- a/lib/text.ts
+++ b/lib/text.ts
@@ -1,0 +1,25 @@
+export const formatFilterLabel = (value: string): string => {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    return '';
+  }
+
+  const formatSegment = (segment: string): string => {
+    if (!segment) {
+      return '';
+    }
+
+    return segment.charAt(0).toUpperCase() + segment.slice(1);
+  };
+
+  return normalized
+    .split(/\s+/)
+    .map((word) =>
+      word
+        .split('-')
+        .map((segment) => formatSegment(segment))
+        .join('-'),
+    )
+    .join(' ');
+};


### PR DESCRIPTION
## Summary
- add a reusable AdditiveGrid component and update the home page to use it
- add dynamic function and origin filter routes with metadata and additive listings
- link additive detail chips to the corresponding filter pages and expose helper utilities for slugs/labels

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e302da11088327b949126501434d03