### PR TITLE
Add FDC product count data and UI sorting controls

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -12,12 +12,13 @@ import {
   getOriginSlug,
 } from '../../lib/additives';
 
-import { formatMonthlyVolume, getCountryFlagEmoji, getCountryLabel } from '../../lib/format';
+import { formatMonthlyVolume, formatProductCount, getCountryFlagEmoji, getCountryLabel } from '../../lib/format';
 import { getSearchHistory } from '../../lib/search-history';
 import { getSearchQuestions } from '../../lib/search-questions';
 import { SearchHistoryChart } from '../../components/SearchHistoryChart';
 import { MarkdownArticle } from '../../components/MarkdownArticle';
 import { SearchQuestions } from '../../components/SearchQuestions';
+import { getFdcProductSearchUrl } from '../../lib/products';
 
 interface AdditivePageProps {
   params: Promise<{ slug: string }>;
@@ -77,6 +78,8 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
   const articleSummary = extractArticleSummary(additive.article);
   const articleBody = extractArticleBody(additive.article);
   const originList = additive.origin.filter((value, index, list) => list.indexOf(value) === index);
+  const productCount = typeof additive.productCount === 'number' ? additive.productCount : null;
+  const productSearchUrl = getFdcProductSearchUrl(additive.title);
 
   return (
     <Box component="article" display="flex" flexDirection="column" gap={4} alignItems="center" width="100%">
@@ -198,6 +201,23 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
               );
             })}
           </Stack>
+        )}
+
+        {productCount !== null && (
+          <Typography variant="body1" color="text.secondary" sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            <Box component="span" sx={{ fontWeight: 600 }}>
+              Products:
+            </Box>
+            <MuiLink
+              href={productSearchUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              underline="hover"
+              sx={{ fontWeight: 500 }}
+            >
+              Appears in {formatProductCount(productCount)} products in FoodData Central
+            </MuiLink>
+          </Typography>
         )}
 
         {articleSummary && (

--- a/components/AdditiveComparison.tsx
+++ b/components/AdditiveComparison.tsx
@@ -8,18 +8,21 @@ import {
   Box,
   Button,
   Chip,
+  Link as MuiLink,
   Stack,
   TextField,
   Typography,
   createFilterOptions,
 } from '@mui/material';
+import LaunchIcon from '@mui/icons-material/Launch';
 import type { Additive } from '../lib/additives';
 import { formatAdditiveDisplayName, formatOriginLabel } from '../lib/additive-format';
 import { extractArticleSummary, splitArticlePreview } from '../lib/article';
-import { formatMonthlyVolume, getCountryFlagEmoji, getCountryLabel } from '../lib/format';
+import { formatMonthlyVolume, formatProductCount, getCountryFlagEmoji, getCountryLabel } from '../lib/format';
 import type { SearchHistoryDataset } from '../lib/search-history';
 import { MarkdownArticle } from './MarkdownArticle';
 import { SearchHistoryChart } from './SearchHistoryChart';
+import { getFdcProductSearchUrl } from '../lib/products';
 
 interface ComparisonAdditive extends Additive {
   searchHistory: SearchHistoryDataset | null;
@@ -111,6 +114,42 @@ const renderOriginContent = (additive: ComparisonAdditive | null) => {
       {origins.map((origin) => (
         <Chip key={origin} label={formatOriginLabel(origin)} variant="outlined" size="small" />
       ))}
+    </Stack>
+  );
+};
+
+const renderProductMetrics = (additive: ComparisonAdditive | null) => {
+  if (!additive) {
+    return null;
+  }
+
+  const productCount = typeof additive.productCount === 'number' ? additive.productCount : null;
+
+  if (productCount === null) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Product count data is not available.
+      </Typography>
+    );
+  }
+
+  const productUrl = getFdcProductSearchUrl(additive.title);
+
+  return (
+    <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="wrap">
+      <Typography component="span" variant="body1" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+        {formatProductCount(productCount)} products
+      </Typography>
+      <MuiLink
+        href={productUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        underline="hover"
+        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, fontWeight: 500 }}
+      >
+        View on FoodData Central
+        <LaunchIcon fontSize="inherit" />
+      </MuiLink>
     </Stack>
   );
 };
@@ -374,6 +413,11 @@ export function AdditiveComparison({ additives, initialSelection }: AdditiveComp
       key: 'origin',
       label: 'Origin',
       render: renderOriginContent,
+    },
+    {
+      key: 'products',
+      label: 'Products',
+      render: renderProductMetrics,
     },
     {
       key: 'search-metrics',

--- a/components/AdditiveGrid.tsx
+++ b/components/AdditiveGrid.tsx
@@ -1,11 +1,37 @@
+'use client';
+
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Avatar, Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
-import type { Theme } from '@mui/material/styles';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+  Link as MuiLink,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import LaunchIcon from '@mui/icons-material/Launch';
 
 import type { Additive } from '../lib/additives';
-import { formatMonthlyVolume } from '../lib/format';
+import { formatMonthlyVolume, formatProductCount } from '../lib/format';
+import { getFdcProductSearchUrl } from '../lib/products';
 import { SearchSparkline } from './SearchSparkline';
 import { theme } from '../lib/theme';
+
+type SortField = 'searchRank' | 'products';
+
+type SortOrder = 'asc' | 'desc';
 
 const getOriginLabel = (origin: string) => {
   const letters = origin.replace(/[^A-Za-z]/g, '');
@@ -20,7 +46,7 @@ const getOriginLabel = (origin: string) => {
   return `${first}${second ? second.toLowerCase() : ''}`;
 };
 
-const getTitleMinHeight = (muiTheme: Theme) => {
+const getTitleMinHeight = (muiTheme: typeof theme) => {
   const toRem = (value: string | number) => {
     if (typeof value === 'number') {
       return value / muiTheme.typography.htmlFontSize;
@@ -65,7 +91,71 @@ interface AdditiveGridProps {
   emptyMessage?: string;
 }
 
+const sortAdditives = (items: Additive[], field: SortField, order: SortOrder): Additive[] => {
+  const copy = [...items];
+
+  if (field === 'products') {
+    copy.sort((a, b) => {
+      const aHas = typeof a.productCount === 'number';
+      const bHas = typeof b.productCount === 'number';
+
+      if (aHas && bHas) {
+        const diff = (a.productCount ?? 0) - (b.productCount ?? 0);
+        return order === 'asc' ? diff : -diff;
+      }
+
+      if (aHas && !bHas) {
+        return -1;
+      }
+
+      if (!aHas && bHas) {
+        return 1;
+      }
+
+      return a.title.localeCompare(b.title);
+    });
+
+    return copy;
+  }
+
+  copy.sort((a, b) => {
+    const aHas = typeof a.searchRank === 'number';
+    const bHas = typeof b.searchRank === 'number';
+
+    if (aHas && bHas) {
+      const diff = (a.searchRank ?? 0) - (b.searchRank ?? 0);
+      return order === 'asc' ? diff : -diff;
+    }
+
+    if (aHas && !bHas) {
+      return order === 'asc' ? -1 : 1;
+    }
+
+    if (!aHas && bHas) {
+      return order === 'asc' ? 1 : -1;
+    }
+
+    return a.title.localeCompare(b.title);
+  });
+
+  return copy;
+};
+
+const getSortOrderLabel = (order: SortOrder, field: SortField): string => {
+  if (field === 'products') {
+    return order === 'asc' ? 'Ascending (fewest first)' : 'Descending (most first)';
+  }
+
+  return order === 'asc' ? 'Ascending (best rank first)' : 'Descending (lowest rank last)';
+};
+
 export function AdditiveGrid({ items, emptyMessage = 'No additives found.' }: AdditiveGridProps) {
+  const [sortField, setSortField] = useState<SortField>('searchRank');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+
+  const sortedItems = useMemo(() => sortAdditives(items, sortField, sortOrder), [items, sortField, sortOrder]);
+  const showProductMode = sortField === 'products';
+
   if (items.length === 0) {
     return (
       <Typography variant="body1" color="text.secondary">
@@ -74,132 +164,217 @@ export function AdditiveGrid({ items, emptyMessage = 'No additives found.' }: Ad
     );
   }
 
+  const handleSortFieldChange = (event: SelectChangeEvent<SortField>) => {
+    const value = event.target.value as SortField;
+    setSortField(value);
+    setSortOrder(value === 'products' ? 'desc' : 'asc');
+  };
+
+  const handleToggleOrder = () => {
+    setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+  };
+
+  const OrderIcon = sortOrder === 'asc' ? ArrowUpwardIcon : ArrowDownwardIcon;
+
   return (
-    <Box
-      display="grid"
-      gap={{ xs: 2, sm: 3 }}
-      sx={{
-        gridTemplateColumns: {
-          xs: '1fr',
-          sm: 'repeat(2, 1fr)',
-          md: 'repeat(3, 1fr)',
-          lg: 'repeat(4, 1fr)',
-        },
-        '@media (min-width: 1600px)': {
-          gridTemplateColumns: 'repeat(6, 1fr)',
-        },
-      }}
-    >
-      {items.map((additive) => {
-        const hasSparkline =
-          Array.isArray(additive.searchSparkline) &&
-          additive.searchSparkline.some((value) => value !== null);
-        const hasSearchMetrics =
-          typeof additive.searchRank === 'number' && typeof additive.searchVolume === 'number';
-        const showSearchSection = hasSparkline || hasSearchMetrics;
-        const visibleFunctions = additive.functions.slice(0, 2);
-        const hiddenFunctionCount = Math.max(additive.functions.length - visibleFunctions.length, 0);
-        const origins = additive.origin.filter((origin) => origin.trim().length > 0);
+    <Stack spacing={2.5} width="100%">
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent={{ xs: 'flex-start', sm: 'flex-end' }}
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={1.5}
+      >
+        <FormControl size="small" sx={{ minWidth: { xs: '100%', sm: 200 } }}>
+          <InputLabel id="additive-sort-label">Sort by</InputLabel>
+          <Select<SortField>
+            labelId="additive-sort-label"
+            id="additive-sort"
+            label="Sort by"
+            value={sortField}
+            onChange={handleSortFieldChange}
+          >
+            <MenuItem value="searchRank">Search rank</MenuItem>
+            <MenuItem value="products">Products</MenuItem>
+          </Select>
+        </FormControl>
 
-        return (
-          <Card key={additive.slug} sx={{ display: 'flex', flexDirection: 'column' }}>
-            <CardActionArea
-              component={Link}
-              href={`/${additive.slug}`}
-              sx={{ flexGrow: 1, display: 'flex', alignItems: 'stretch' }}
-            >
-              <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-                <Stack spacing={1.5} sx={{ flexGrow: 1 }}>
-                  <Box display="flex" justifyContent="space-between" alignItems="flex-start">
-                    <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
-                      {additive.eNumber}
+        <IconButton
+          onClick={handleToggleOrder}
+          aria-label={`Toggle sort order: ${getSortOrderLabel(sortOrder, sortField)}`}
+          title={getSortOrderLabel(sortOrder, sortField)}
+          sx={{
+            alignSelf: { xs: 'flex-end', sm: 'center' },
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 2,
+            width: 40,
+            height: 40,
+          }}
+        >
+          <OrderIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      <Box
+        display="grid"
+        gap={{ xs: 2, sm: 3 }}
+        sx={{
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, 1fr)',
+            md: 'repeat(3, 1fr)',
+            lg: 'repeat(4, 1fr)',
+          },
+          '@media (min-width: 1600px)': {
+            gridTemplateColumns: 'repeat(6, 1fr)',
+          },
+        }}
+      >
+        {sortedItems.map((additive) => {
+          const hasSparkline =
+            Array.isArray(additive.searchSparkline) && additive.searchSparkline.some((value) => value !== null);
+          const hasSearchMetrics =
+            typeof additive.searchRank === 'number' && typeof additive.searchVolume === 'number';
+          const origins = additive.origin.filter((origin) => origin.trim().length > 0);
+          const productCount = typeof additive.productCount === 'number' ? additive.productCount : null;
+          const productSearchUrl = getFdcProductSearchUrl(additive.title);
+          const visibleFunctions = additive.functions.slice(0, 2);
+          const hiddenFunctionCount = Math.max(additive.functions.length - visibleFunctions.length, 0);
+
+          return (
+            <Card key={additive.slug} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+              <CardActionArea
+                component={Link}
+                href={`/${additive.slug}`}
+                sx={{ flexGrow: 1, display: 'flex', alignItems: 'stretch' }}
+              >
+                <CardContent sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+                  <Stack spacing={1.5} sx={{ flexGrow: 1 }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="flex-start">
+                      <Typography variant="overline" color="text.secondary" letterSpacing={1.2}>
+                        {additive.eNumber}
+                      </Typography>
+                      {origins.length > 0 ? (
+                        <Stack direction="row" spacing={0.5}>
+                          {origins.map((origin) => {
+                            const label = getOriginLabel(origin);
+
+                            return (
+                              <Avatar
+                                key={origin}
+                                variant="circular"
+                                sx={{
+                                  width: 28,
+                                  height: 28,
+                                  bgcolor: 'grey.100',
+                                  color: 'text.primary',
+                                  fontSize: 12,
+                                  fontWeight: 600,
+                                }}
+                              >
+                                {label}
+                              </Avatar>
+                            );
+                          })}
+                        </Stack>
+                      ) : (
+                        <Box sx={{ minHeight: 28, minWidth: 28 }} />
+                      )}
+                    </Box>
+
+                    <Typography
+                      component="h2"
+                      variant="h2"
+                      sx={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                        minHeight: titleMinHeight,
+                      }}
+                    >
+                      {additive.title}
                     </Typography>
-                    {origins.length > 0 ? (
-                      <Stack direction="row" spacing={0.5}>
-                        {origins.map((origin) => {
-                          const label = getOriginLabel(origin);
 
-                          return (
-                            <Avatar
-                              key={origin}
-                              variant="circular"
-                              sx={{
-                                width: 28,
-                                height: 28,
-                                bgcolor: 'grey.100',
-                                color: 'text.primary',
-                                fontSize: 12,
-                                fontWeight: 600,
-                              }}
-                            >
-                              {label}
-                            </Avatar>
-                          );
-                        })}
+                    {visibleFunctions.length > 0 ? (
+                      <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'nowrap', minHeight: 28 }}>
+                        {visibleFunctions.map((fn) => (
+                          <Chip key={fn} label={fn} variant="outlined" size="small" />
+                        ))}
+                        {hiddenFunctionCount > 0 && (
+                          <Chip label={`+${hiddenFunctionCount}`} variant="outlined" size="small" />
+                        )}
                       </Stack>
                     ) : (
-                      <Box sx={{ minHeight: 28, minWidth: 28 }} />
+                      <Box sx={{ minHeight: 28 }} />
                     )}
-                  </Box>
+                  </Stack>
 
-                  <Typography
-                    component="h2"
-                    variant="h2"
-                    sx={{
-                      display: '-webkit-box',
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: 'vertical',
-                      overflow: 'hidden',
-                      minHeight: titleMinHeight,
-                    }}
-                  >
-                    {additive.title}
-                  </Typography>
-
-                  {visibleFunctions.length > 0 ? (
-                    <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'nowrap', minHeight: 28 }}>
-                      {visibleFunctions.map((fn) => (
-                        <Chip key={fn} label={fn} variant="outlined" size="small" />
-                      ))}
-                      {hiddenFunctionCount > 0 && (
-                        <Chip label={`+${hiddenFunctionCount}`} variant="outlined" size="small" />
+                  {!showProductMode ? (
+                    <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mt: 1.5 }}>
+                      {hasSearchMetrics ? (
+                        <Stack direction="row" alignItems="baseline" spacing={1} flexShrink={0}>
+                          <Typography component="span" variant="subtitle1" fontWeight={600}>
+                            #{additive.searchRank}
+                          </Typography>
+                          <Typography component="span" variant="body2" color="text.secondary">
+                            {formatMonthlyVolume(additive.searchVolume!)} / mo
+                          </Typography>
+                        </Stack>
+                      ) : (
+                        <Box sx={{ minWidth: 0 }} />
+                      )}
+                      {hasSparkline ? (
+                        <Box sx={{ flexGrow: 1, minWidth: 96 }}>
+                          <SearchSparkline values={additive.searchSparkline ?? []} />
+                        </Box>
+                      ) : (
+                        <Box sx={{ flexGrow: 1, height: 40 }} />
                       )}
                     </Stack>
                   ) : (
-                    <Box sx={{ minHeight: 28 }} />
+                    <Box sx={{ mt: 1.5, minHeight: 40 }} />
                   )}
-                </Stack>
+                </CardContent>
+              </CardActionArea>
 
-                {showSearchSection ? (
-                  <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mt: 1.5 }}>
-                    {hasSearchMetrics ? (
-                      <Stack direction="row" alignItems="baseline" spacing={1} flexShrink={0}>
-                        <Typography component="span" variant="subtitle1" fontWeight={600}>
-                          #{additive.searchRank}
-                        </Typography>
-                        <Typography component="span" variant="body2" color="text.secondary">
-                          {formatMonthlyVolume(additive.searchVolume!)} / mo
-                        </Typography>
-                      </Stack>
-                    ) : (
-                      <Box sx={{ minWidth: 0 }} />
-                    )}
-                    {hasSparkline ? (
-                      <Box sx={{ flexGrow: 1, minWidth: 96 }}>
-                        <SearchSparkline values={additive.searchSparkline ?? []} />
-                      </Box>
-                    ) : (
-                      <Box sx={{ flexGrow: 1, height: 40 }} />
-                    )}
-                  </Stack>
-                ) : (
-                  <Box sx={{ height: 40, mt: 1.5 }} />
-                )}
-              </CardContent>
-            </CardActionArea>
-          </Card>
-        );
-      })}
-    </Box>
+              {showProductMode ? (
+                <Box
+                  sx={{
+                    px: 3,
+                    py: 1.75,
+                    borderTop: '1px solid',
+                    borderColor: 'divider',
+                    display: 'flex',
+                    flexDirection: { xs: 'column', sm: 'row' },
+                    gap: 1,
+                    justifyContent: 'space-between',
+                    alignItems: { xs: 'flex-start', sm: 'center' },
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    {productCount !== null
+                      ? `Found in ${formatProductCount(productCount)} products`
+                      : 'Product count unavailable.'}
+                  </Typography>
+                  {productCount !== null ? (
+                    <MuiLink
+                      href={productSearchUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      underline="hover"
+                      sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, fontWeight: 500 }}
+                    >
+                      View products
+                      <LaunchIcon fontSize="inherit" />
+                    </MuiLink>
+                  ) : null}
+                </Box>
+              ) : null}
+            </Card>
+          );
+        })}
+      </Box>
+    </Stack>
   );
 }

--- a/data/e1503-castor-oil/props.json
+++ b/data/e1503-castor-oil/props.json
@@ -28,5 +28,6 @@
   ],
   "origin": [
     "plant"
-  ]
+  ],
+  "productCount": 206383
 }

--- a/data/e345-magnesium-citrate/props.json
+++ b/data/e345-magnesium-citrate/props.json
@@ -27,5 +27,6 @@
     "microbiological",
     "synthetic",
     "mineral"
-  ]
+  ],
+  "productCount": 30273
 }

--- a/lib/additives.ts
+++ b/lib/additives.ts
@@ -16,6 +16,7 @@ export interface AdditivePropsFile {
   searchSparkline?: unknown;
   searchVolume?: unknown;
   searchRank?: unknown;
+  productCount?: unknown;
 }
 
 export interface Additive {
@@ -32,6 +33,7 @@ export interface Additive {
   searchSparkline: Array<number | null>;
   searchVolume: number | null;
   searchRank: number | null;
+  productCount: number | null;
 }
 
 interface AdditiveIndexEntry {
@@ -128,6 +130,7 @@ const readAdditiveProps = (
       searchSparkline: [],
       searchVolume: null,
       searchRank: null,
+      productCount: null,
     };
   }
 
@@ -151,6 +154,7 @@ const readAdditiveProps = (
       searchSparkline: toSparkline(parsed.searchSparkline),
       searchVolume: toOptionalNumber(parsed.searchVolume),
       searchRank: toOptionalNumber(parsed.searchRank),
+      productCount: toOptionalNumber(parsed.productCount),
     };
   } catch (error) {
     console.error(`Failed to read additive props for ${slug}:`, error);
@@ -170,6 +174,7 @@ const readAdditiveProps = (
       searchSparkline: [],
       searchVolume: null,
       searchRank: null,
+      productCount: null,
     };
   }
 };

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -14,6 +14,16 @@ export const formatMonthlyVolume = (value: number): string => {
   return `${Math.round(value)}`;
 };
 
+const productCountFormatter = new Intl.NumberFormat('en-US');
+
+export const formatProductCount = (value: number): string => {
+  if (!Number.isFinite(value)) {
+    return '';
+  }
+
+  return productCountFormatter.format(Math.round(value));
+};
+
 const COUNTRY_NAME_MAP: Record<string, string> = {
   US: 'United States',
 };

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,6 @@
+const FDC_SEARCH_BASE_URL = 'https://fdc.nal.usda.gov/food-search?type=Branded&query=&ingredients=';
+
+export const getFdcProductSearchUrl = (title: string): string => {
+  const query = title ? encodeURIComponent(title.trim()) : '';
+  return `${FDC_SEARCH_BASE_URL}${query}`;
+};

--- a/scripts/fetch-product-counts.js
+++ b/scripts/fetch-product-counts.js
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+
+/**
+ * Fetches the number of branded products from the USDA FoodData Central API
+ * for each additive and stores the total hit count in `data/<slug>/props.json`
+ * under the `productCount` property.
+ *
+ * Usage examples:
+ *   node scripts/fetch-product-counts.js --additive e345-magnesium-citrate
+ *   node scripts/fetch-product-counts.js --skip-existing
+ *   node scripts/fetch-product-counts.js --additive=e345-magnesium-citrate,e1503-castor-oil --debug
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const { createAdditiveSlug } = require('./utils/slug');
+
+const execFileAsync = promisify(execFile);
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const ADDITIVES_INDEX_PATH = path.join(DATA_DIR, 'additives.json');
+const API_URL = 'https://api.nal.usda.gov/fdc/v1/foods/search';
+const DEFAULT_API_KEY = 'EHf6ZHx4AhcsX31cgTsB2Avud7ckR6fBJXDF4fDg';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const getApiKey = () => process.env.FDC_API_KEY || DEFAULT_API_KEY;
+
+const propsPathForSlug = (slug) => path.join(DATA_DIR, slug, 'props.json');
+
+const readAdditivesIndex = async () => {
+  const raw = await fs.readFile(ADDITIVES_INDEX_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  if (!Array.isArray(parsed.additives)) {
+    throw new Error('Unexpected additives index format.');
+  }
+
+  return parsed.additives.map((entry) => ({
+    title: typeof entry.title === 'string' ? entry.title : '',
+    eNumber: typeof entry.eNumber === 'string' ? entry.eNumber : '',
+    slug: createAdditiveSlug({ eNumber: entry.eNumber, title: entry.title }),
+  }));
+};
+
+const ensureProps = (props, fallback) => {
+  const result = props && typeof props === 'object' ? { ...props } : {};
+
+  if (typeof result.title !== 'string') {
+    result.title = fallback.title || '';
+  }
+  if (typeof result.eNumber !== 'string') {
+    result.eNumber = fallback.eNumber || '';
+  }
+  if (!Array.isArray(result.synonyms)) {
+    result.synonyms = [];
+  }
+  if (!Array.isArray(result.functions)) {
+    result.functions = [];
+  }
+  if (!Array.isArray(result.origin)) {
+    result.origin = [];
+  }
+  if (typeof result.description !== 'string') {
+    result.description = '';
+  }
+  if (typeof result.wikipedia !== 'string') {
+    result.wikipedia = '';
+  }
+  if (typeof result.wikidata !== 'string') {
+    result.wikidata = '';
+  }
+  if (!Array.isArray(result.searchSparkline)) {
+    result.searchSparkline = [];
+  }
+  if (typeof result.searchVolume !== 'number') {
+    result.searchVolume = null;
+  }
+  if (typeof result.searchRank !== 'number') {
+    result.searchRank = null;
+  }
+  if (typeof result.productCount !== 'number') {
+    result.productCount = null;
+  }
+
+  return result;
+};
+
+const readProps = async (slug, fallback) => {
+  try {
+    const raw = await fs.readFile(propsPathForSlug(slug), 'utf8');
+    const parsed = JSON.parse(raw);
+    return ensureProps(parsed, fallback);
+  } catch (error) {
+    return ensureProps(null, fallback);
+  }
+};
+
+const writeProps = async (slug, props) => {
+  await fs.mkdir(path.join(DATA_DIR, slug), { recursive: true });
+  await fs.writeFile(propsPathForSlug(slug), `${JSON.stringify(props, null, 2)}\n`);
+};
+
+const parseArgs = (argv) => {
+  const args = argv.slice(2);
+  const result = {
+    additiveSlugs: [],
+    debug: false,
+    skipExisting: false,
+    help: false,
+  };
+
+  const pushSlugValues = (value) => {
+    if (!value) {
+      return;
+    }
+
+    value
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .forEach((part) => {
+        if (!result.additiveSlugs.includes(part)) {
+          result.additiveSlugs.push(part);
+        }
+      });
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case '--help':
+      case '-h':
+        result.help = true;
+        break;
+      case '--debug':
+      case '-d':
+        result.debug = true;
+        break;
+      case '--skip-existing':
+      case '--skip':
+        result.skipExisting = true;
+        break;
+      case '--additive':
+      case '-additive':
+      case '-a': {
+        const next = args[index + 1];
+        if (!next) {
+          throw new Error('Missing value for --additive flag.');
+        }
+        pushSlugValues(next);
+        index += 1;
+        break;
+      }
+      default:
+        if (arg.startsWith('--additive=')) {
+          pushSlugValues(arg.slice('--additive='.length));
+          break;
+        }
+        if (arg.startsWith('-additive=')) {
+          pushSlugValues(arg.slice('-additive='.length));
+          break;
+        }
+        if (arg.startsWith('-a=')) {
+          pushSlugValues(arg.slice(3));
+          break;
+        }
+        if (arg.startsWith('--')) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        pushSlugValues(arg);
+        break;
+    }
+  }
+
+  return result;
+};
+
+const printHelp = () => {
+  console.log(`Usage: node fetch-product-counts.js [options]\n\nOptions:\n  --additive, -a <slug[,slug...]>  Only process specific additive slugs.\n  --skip-existing                 Skip additives that already have a productCount.\n  --debug                         Log API requests and responses.\n  --help                          Show this message.`);
+};
+
+const fetchProductCount = async ({ apiKey, title, debug = false }) => {
+  const payload = {
+    query: title,
+    dataType: ['Branded'],
+    pageSize: 200,
+    pageNumber: 1,
+  };
+
+  const url = `${API_URL}?api_key=${encodeURIComponent(apiKey)}`;
+  const body = JSON.stringify(payload);
+
+  if (debug) {
+    console.log(`→ Requesting products for "${title}"`);
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      'curl',
+      [
+        '-fsS',
+        '-X',
+        'POST',
+        '-H',
+        'Content-Type: application/json',
+        '-d',
+        body,
+        url,
+      ],
+      { maxBuffer: 10 * 1024 * 1024 },
+    );
+
+    const parsed = JSON.parse(stdout);
+    const totalHits = typeof parsed.totalHits === 'number' ? parsed.totalHits : null;
+
+    if (debug) {
+      console.log(`  totalHits: ${totalHits ?? 'null'}`);
+    }
+
+    return totalHits;
+  } catch (error) {
+    if (debug) {
+      const stderr = error.stderr ? error.stderr.toString() : error.message;
+      console.error(`  Request failed: ${stderr}`);
+    }
+    throw error;
+  }
+};
+
+async function processAdditive({
+  apiKey,
+  additive,
+  skipExisting,
+  debug,
+  delayMs,
+}) {
+  if (!additive.title) {
+    if (debug) {
+      console.log(`Skipping ${additive.slug} because it has no title.`);
+    }
+    return { updated: false };
+  }
+
+  const props = await readProps(additive.slug, additive);
+
+  if (skipExisting && typeof props.productCount === 'number') {
+    if (debug) {
+      console.log(`Skipping ${additive.slug} (productCount already set).`);
+    }
+    return { updated: false };
+  }
+
+  const count = await fetchProductCount({ apiKey, title: additive.title, debug });
+
+  props.productCount = typeof count === 'number' ? count : null;
+
+  await writeProps(additive.slug, props);
+
+  if (delayMs > 0) {
+    await sleep(delayMs);
+  }
+
+  return { updated: true, count };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const apiKey = getApiKey();
+  const additives = await readAdditivesIndex();
+  let targets = additives;
+
+  if (args.additiveSlugs.length > 0) {
+    const slugSet = new Set(args.additiveSlugs);
+    targets = additives.filter((item) => slugSet.has(item.slug));
+
+    const missing = args.additiveSlugs.filter((slug) => !targets.some((item) => item.slug === slug));
+    if (missing.length > 0) {
+      console.warn(`⚠️  Unknown additive slugs: ${missing.join(', ')}`);
+    }
+  }
+
+  if (targets.length === 0) {
+    console.log('No additives to process.');
+    return;
+  }
+
+  console.log(`Processing ${targets.length} additive(s).`);
+
+  let processed = 0;
+  for (const additive of targets) {
+    processed += 1;
+    const label = [additive.eNumber, additive.title].filter(Boolean).join(' - ') || additive.slug;
+    try {
+      const { updated, count } = await processAdditive({
+        apiKey,
+        additive,
+        skipExisting: args.skipExisting,
+        debug: args.debug,
+        delayMs: 150,
+      });
+
+      if (updated) {
+        console.log(`[${processed}/${targets.length}] ${label}: ${typeof count === 'number' ? count : 'no data'}`);
+      } else {
+        console.log(`[${processed}/${targets.length}] ${label}: skipped`);
+      }
+    } catch (error) {
+      console.error(`[${processed}/${targets.length}] Failed to update ${label}: ${error.message}`);
+    }
+  }
+
+  console.log('Finished processing product counts.');
+}
+
+main().catch((error) => {
+  console.error('Unexpected error while fetching product counts:', error);
+  process.exitCode = 1;
+});

--- a/scripts/fetch-search-history.js
+++ b/scripts/fetch-search-history.js
@@ -83,6 +83,9 @@ const ensureProps = (props, additive) => {
   if (!Array.isArray(result.searchSparkline)) {
     result.searchSparkline = [];
   }
+  if (typeof result.productCount !== 'number') {
+    result.productCount = null;
+  }
 
   return result;
 };

--- a/scripts/update-search-volume.js
+++ b/scripts/update-search-volume.js
@@ -87,6 +87,9 @@ const ensureProps = (props, fallback) => {
   if (typeof result.searchRank !== 'number') {
     result.searchRank = null;
   }
+  if (typeof result.productCount !== 'number') {
+    result.productCount = null;
+  }
 
   return result;
 };


### PR DESCRIPTION
## Summary
- add a FoodData Central product count fetcher script that stores results in each additive’s props
- display product counts across additive cards, detail pages, and comparisons with a toggleable sort control
- add formatting helpers and sample product count data for magnesium citrate and castor oil

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e413b74b208327a9196d8cd292efea