### PR TITLE
Add global additive search widget

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -44,8 +44,10 @@ a {
 }
 
 .header-shell {
-  margin-left: 0;
-  margin-right: auto;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0 1.5rem;
 }
 
 .header-content {
@@ -53,6 +55,7 @@ a {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
+  width: 100%;
 }
 
 .header-nav {
@@ -66,7 +69,7 @@ a {
 
 .header-search {
   flex: 0 0 auto;
-  width: 120px;
+  width: 88px;
   transition: width 0.25s ease;
 }
 
@@ -114,6 +117,10 @@ a {
 
   .site-header {
     padding: 0.75rem 0;
+  }
+
+  .header-shell {
+    padding: 0 1rem;
   }
 
   .header-content {

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,7 +51,7 @@ a {
 .header-content {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 1.5rem;
 }
 
@@ -60,11 +60,13 @@ a {
   align-items: center;
   gap: 1.25rem;
   margin-left: auto;
+  justify-content: flex-end;
+  flex: 1 1 auto;
 }
 
 .header-search {
   flex: 0 0 auto;
-  width: 160px;
+  width: 120px;
   transition: width 0.25s ease;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -69,7 +69,7 @@ a {
 
 .header-search {
   flex: 0 0 auto;
-  width: 88px;
+  width: 120px;
   transition: width 0.25s ease;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,7 +51,7 @@ a {
 .header-content {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 1.5rem;
 }
 
@@ -59,11 +59,12 @@ a {
   display: flex;
   align-items: center;
   gap: 1.25rem;
+  margin-left: auto;
 }
 
 .header-search {
   flex: 0 0 auto;
-  width: 220px;
+  width: 160px;
   transition: width 0.25s ease;
 }
 
@@ -124,6 +125,7 @@ a {
     flex-direction: column;
     align-items: stretch;
     gap: 0.75rem;
+    margin-left: 0;
   }
 
   .header-search {

--- a/app/globals.css
+++ b/app/globals.css
@@ -61,6 +61,21 @@ a {
   gap: 1.25rem;
 }
 
+.header-search {
+  flex: 0 0 auto;
+  width: 220px;
+  transition: width 0.25s ease;
+}
+
+.header-search:focus-within,
+.header-search[data-active='true'] {
+  width: 320px;
+}
+
+.header-search .MuiAutocomplete-root {
+  width: 100%;
+}
+
 .header-link {
   font-size: 0.95rem;
   font-weight: 600;
@@ -102,6 +117,17 @@ a {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
+  }
+
+  .header-nav {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .header-search {
+    width: 100%;
   }
 
   .site-footer {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import { Typography } from '@mui/material';
 import { Roboto } from 'next/font/google';
 
 import { Providers } from '../components/Providers';
+import { HeaderSearch } from '../components/HeaderSearch';
+import { getAdditives } from '../lib/additives';
 import './globals.css';
 
 const roboto = Roboto({
@@ -24,6 +26,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const additives = getAdditives();
+
   return (
     <html lang="en">
       <body className={roboto.className}>
@@ -46,6 +50,7 @@ export default function RootLayout({
                     </Typography>
                   </Link>
                   <nav className="header-nav">
+                    <HeaderSearch additives={additives} />
                     <Link href="/compare" className="header-link">
                       Compare
                     </Link>

--- a/components/AdditiveComparison.tsx
+++ b/components/AdditiveComparison.tsx
@@ -3,22 +3,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import {
-  Autocomplete,
-  Box,
-  Button,
-  Chip,
-  Stack,
-  TextField,
-  Typography,
-  createFilterOptions,
-} from '@mui/material';
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
 import type { Additive } from '../lib/additives';
 import { formatAdditiveDisplayName, formatOriginLabel } from '../lib/additive-format';
 import { extractArticleSummary, splitArticlePreview } from '../lib/article';
 import { formatMonthlyVolume, getCountryFlagEmoji, getCountryLabel } from '../lib/format';
 import type { SearchHistoryDataset } from '../lib/search-history';
 import { MarkdownArticle } from './MarkdownArticle';
+import { AdditiveLookup } from './AdditiveLookup';
 import { SearchHistoryChart } from './SearchHistoryChart';
 
 interface ComparisonAdditive extends Additive {
@@ -34,14 +26,6 @@ interface SelectionState {
   left: ComparisonAdditive | null;
   right: ComparisonAdditive | null;
 }
-
-const createOptionFilter = createFilterOptions<ComparisonAdditive>({
-  stringify: (option) => {
-    const synonymString = option.synonyms.join(' ');
-
-    return [option.eNumber, option.title, synonymString].filter(Boolean).join(' ');
-  },
-});
 
 const renderSynonymContent = (additive: ComparisonAdditive | null) => {
   if (!additive) {
@@ -412,29 +396,21 @@ export function AdditiveComparison({ additives, initialSelection }: AdditiveComp
           gridTemplateColumns: { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' },
         }}
       >
-        <Autocomplete
-          options={additives}
+        <AdditiveLookup
+          additives={additives}
           value={selection.left}
-          onChange={(_, value) => setSelection((prev) => ({ ...prev, left: value }))}
-          getOptionLabel={(option) => formatAdditiveDisplayName(option.eNumber, option.title)}
-          filterOptions={createOptionFilter}
-          renderInput={(params) => <TextField {...params} label="Select first additive" placeholder="Type additive to compare" />}
-          isOptionEqualToValue={(option, value) => option.slug === value.slug}
-          getOptionDisabled={(option) => option.slug === selection.right?.slug}
-          clearOnBlur={false}
-          autoHighlight
+          onChange={(value) => setSelection((prev) => ({ ...prev, left: value }))}
+          label="Select first additive"
+          placeholder="Type additive to compare"
+          disabledSlugs={selection.right ? [selection.right.slug] : undefined}
         />
-        <Autocomplete
-          options={additives}
+        <AdditiveLookup
+          additives={additives}
           value={selection.right}
-          onChange={(_, value) => setSelection((prev) => ({ ...prev, right: value }))}
-          getOptionLabel={(option) => formatAdditiveDisplayName(option.eNumber, option.title)}
-          filterOptions={createOptionFilter}
-          renderInput={(params) => <TextField {...params} label="Select second additive" placeholder="Type additive to compare" />}
-          isOptionEqualToValue={(option, value) => option.slug === value.slug}
-          getOptionDisabled={(option) => option.slug === selection.left?.slug}
-          clearOnBlur={false}
-          autoHighlight
+          onChange={(value) => setSelection((prev) => ({ ...prev, right: value }))}
+          label="Select second additive"
+          placeholder="Type additive to compare"
+          disabledSlugs={selection.left ? [selection.left.slug] : undefined}
         />
       </Box>
 

--- a/components/AdditiveLookup.tsx
+++ b/components/AdditiveLookup.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { Fragment, useMemo, useRef, useState, useTransition, type ReactNode } from 'react';
+import { Autocomplete, Box, CircularProgress, Stack, TextField, Typography } from '@mui/material';
+import type { TextFieldProps } from '@mui/material/TextField';
+
+import type { Additive } from '../lib/additives';
+import { formatAdditiveDisplayName } from '../lib/additive-format';
+import type { AdditiveSearchMatch, HighlightRange } from '../lib/additive-search';
+import { searchAdditives } from '../lib/additive-search';
+
+interface AdditiveLookupProps<TAdditive extends Additive> {
+  additives: TAdditive[];
+  value: TAdditive | null;
+  onChange: (value: TAdditive | null) => void;
+  label?: string;
+  placeholder?: string;
+  disabledSlugs?: readonly string[];
+  autoFocus?: boolean;
+  id?: string;
+  maxResults?: number;
+  onResultsChange?: (results: AdditiveSearchMatch<TAdditive>[], query: string) => void;
+  onInputValueChange?: (value: string) => void;
+  textFieldProps?: TextFieldProps;
+  clearOnSelect?: boolean;
+}
+
+type MatchesMap<TAdditive extends Additive> = Map<string, AdditiveSearchMatch<TAdditive>['matches']>;
+
+const renderHighlightedText = (text: string, ranges: HighlightRange[]): ReactNode => {
+  if (!text) {
+    return null;
+  }
+
+  if (!Array.isArray(ranges) || ranges.length === 0) {
+    return text;
+  }
+
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+
+  ranges
+    .slice()
+    .sort((a, b) => a.start - b.start)
+    .forEach((range, index) => {
+      if (range.start > cursor) {
+        parts.push(text.slice(cursor, range.start));
+      }
+
+      parts.push(
+        <Box key={`match-${index}`} component="strong" sx={{ fontWeight: 700 }}>
+          {text.slice(range.start, range.end)}
+        </Box>,
+      );
+
+      cursor = range.end;
+    });
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+
+  return parts;
+};
+
+export function AdditiveLookup<TAdditive extends Additive>({
+  additives,
+  value,
+  onChange,
+  label,
+  placeholder,
+  disabledSlugs,
+  autoFocus,
+  id,
+  maxResults = 50,
+  onResultsChange,
+  onInputValueChange,
+  textFieldProps,
+  clearOnSelect = false,
+}: AdditiveLookupProps<TAdditive>) {
+  const [inputValue, setInputValue] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSearching, startTransition] = useTransition();
+  const [results, setResults] = useState<AdditiveSearchMatch<TAdditive>[]>([]);
+  const matchesRef = useRef<MatchesMap<TAdditive>>(new Map());
+
+  const disabledSet = useMemo(() => new Set(disabledSlugs ?? []), [disabledSlugs]);
+
+  const normalizedQuery = inputValue.trim();
+
+  const displayOptions = useMemo(() => {
+    if (normalizedQuery.length === 0) {
+      return additives;
+    }
+
+    return results.map((result) => result.additive);
+  }, [additives, normalizedQuery.length, results]);
+
+  const noOptionsText = normalizedQuery.length > 0 ? 'No additives found' : 'Start typing to search';
+
+  const handleSearch = (query: string) => {
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+      matchesRef.current = new Map();
+      setResults([]);
+      if (onResultsChange) {
+        onResultsChange([], '');
+      }
+      return;
+    }
+
+    startTransition(() => {
+      const computed = searchAdditives(additives, trimmed, { maxResults });
+      matchesRef.current = new Map(computed.map((item) => [item.additive.slug, item.matches]));
+      setResults(computed);
+      if (onResultsChange) {
+        onResultsChange(computed, trimmed);
+      }
+    });
+  };
+
+  return (
+    <Autocomplete
+      id={id}
+      value={value}
+      open={isOpen}
+      options={displayOptions}
+      autoHighlight
+      clearOnBlur={false}
+      includeInputInList
+      loading={isSearching}
+      filterOptions={(options) => options}
+      onOpen={() => {
+        setIsOpen(true);
+        handleSearch(inputValue);
+      }}
+      onClose={() => setIsOpen(false)}
+      onChange={(_, nextValue) => {
+        onChange(nextValue ?? null);
+        if (clearOnSelect) {
+          matchesRef.current = new Map();
+          setResults([]);
+          setInputValue('');
+          if (onInputValueChange) {
+            onInputValueChange('');
+          }
+          if (onResultsChange) {
+            onResultsChange([], '');
+          }
+        }
+      }}
+      onInputChange={(_, nextInput, reason) => {
+        setInputValue(nextInput);
+        if (onInputValueChange) {
+          onInputValueChange(nextInput);
+        }
+
+        if (reason === 'input' || reason === 'reset') {
+          handleSearch(nextInput);
+        }
+
+        if (reason === 'clear') {
+          handleSearch('');
+        }
+      }}
+      inputValue={inputValue}
+      getOptionLabel={(option) => formatAdditiveDisplayName(option.eNumber, option.title)}
+      isOptionEqualToValue={(option, optionValue) => option.slug === optionValue.slug}
+      getOptionDisabled={(option) => disabledSet.has(option.slug)}
+      renderInput={(params) => (
+        (() => {
+          const {
+            InputProps: textFieldInputProps,
+            label: customLabel,
+            placeholder: customPlaceholder,
+            autoFocus: customAutoFocus,
+            ...otherTextFieldProps
+          } = textFieldProps ?? {};
+          const mergedInputProps = {
+            ...params.InputProps,
+            ...textFieldInputProps,
+            endAdornment: (
+              <Fragment>
+                {isSearching ? <CircularProgress color="inherit" size={18} /> : null}
+                {textFieldInputProps?.endAdornment}
+                {params.InputProps.endAdornment}
+              </Fragment>
+            ),
+          };
+
+          return (
+        <TextField
+          {...params}
+          {...otherTextFieldProps}
+          label={customLabel ?? label}
+          placeholder={customPlaceholder ?? placeholder}
+          autoFocus={customAutoFocus ?? autoFocus}
+          InputProps={mergedInputProps}
+        />
+          );
+        })()
+      )}
+      renderOption={(props, option) => {
+        const matches = matchesRef.current.get(option.slug);
+        const eNumberContent = renderHighlightedText(option.eNumber, matches?.eNumber ?? []);
+        const titleContent = renderHighlightedText(option.title, matches?.title ?? []);
+        const synonymContent = matches?.synonym
+          ? renderHighlightedText(matches.synonym.value, matches.synonym.ranges)
+          : null;
+
+        return (
+          <li {...props} key={option.slug}>
+            <Stack spacing={synonymContent ? 0.25 : 0}>
+              <Typography component="div" variant="body1">
+                <Box component="span">{eNumberContent}</Box>
+                {' — '}
+                <Box component="span">{titleContent}</Box>
+              </Typography>
+              {synonymContent ? (
+                <Typography component="div" variant="body2" color="text.secondary">
+                  {synonymContent}
+                </Typography>
+              ) : null}
+            </Stack>
+          </li>
+        );
+      }}
+      noOptionsText={noOptionsText}
+    />
+  );
+}

--- a/components/AdditiveLookup.tsx
+++ b/components/AdditiveLookup.tsx
@@ -25,6 +25,7 @@ interface AdditiveLookupProps<TAdditive extends Additive> {
   textFieldProps?: TextFieldProps;
   clearOnSelect?: boolean;
   showPopupIcon?: boolean;
+  transformInputDisplayValue?: (value: string) => string;
 }
 
 type MatchesMap<TAdditive extends Additive> = Map<string, AdditiveSearchMatch<TAdditive>['matches']>;
@@ -94,6 +95,7 @@ export function AdditiveLookup<TAdditive extends Additive>({
   textFieldProps,
   clearOnSelect = false,
   showPopupIcon = true,
+  transformInputDisplayValue,
 }: AdditiveLookupProps<TAdditive>) {
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
@@ -250,6 +252,18 @@ export function AdditiveLookup<TAdditive extends Additive>({
                 : false,
           } as typeof params.inputProps;
 
+          const finalInputProps = transformInputDisplayValue
+            ? (() => {
+                const rawValue = params.inputProps.value ?? '';
+                const normalizedValue = typeof rawValue === 'string' ? rawValue : String(rawValue);
+
+                return {
+                  ...mergedInputBaseProps,
+                  value: transformInputDisplayValue(normalizedValue),
+                };
+              })()
+            : mergedInputBaseProps;
+
           return (
             <TextField
               {...params}
@@ -259,7 +273,7 @@ export function AdditiveLookup<TAdditive extends Additive>({
               autoFocus={customAutoFocus ?? autoFocus}
               autoComplete={otherTextFieldProps?.autoComplete ?? 'off'}
               InputProps={mergedInputProps}
-              inputProps={mergedInputBaseProps}
+              inputProps={finalInputProps}
             />
           );
         })()

--- a/components/HeaderSearch.tsx
+++ b/components/HeaderSearch.tsx
@@ -45,9 +45,21 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
 
   const normalizedQuery = query.trim();
   const placeholder = !isFocused && normalizedQuery.length === 0 ? 'Search' : undefined;
+  const shouldCollapseValue = !isFocused && normalizedQuery.length > 0;
+
+  const transformDisplayValue = useCallback(
+    (value: string) => {
+      if (shouldCollapseValue) {
+        return '...';
+      }
+
+      return value;
+    },
+    [shouldCollapseValue],
+  );
 
   return (
-    <Box className="header-search" data-active={isFocused || normalizedQuery.length > 0 ? 'true' : undefined}>
+    <Box className="header-search" data-active={isFocused ? 'true' : undefined}>
       <AdditiveLookup
         additives={additives}
         value={value}
@@ -97,6 +109,7 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
             ),
           },
         }}
+        transformInputDisplayValue={transformDisplayValue}
       />
     </Box>
   );

--- a/components/HeaderSearch.tsx
+++ b/components/HeaderSearch.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Box } from '@mui/material';
+
+import type { Additive } from '../lib/additives';
+import type { AdditiveSearchMatch } from '../lib/additive-search';
+import { AdditiveLookup } from './AdditiveLookup';
+
+interface HeaderSearchProps {
+  additives: Additive[];
+}
+
+export function HeaderSearch({ additives }: HeaderSearchProps) {
+  const router = useRouter();
+  const [value, setValue] = useState<Additive | null>(null);
+  const [results, setResults] = useState<AdditiveSearchMatch<Additive>[]>([]);
+  const [query, setQuery] = useState('');
+  const [lastSearchQuery, setLastSearchQuery] = useState('');
+
+  const navigateToAdditive = useCallback(
+    (slug: string | null | undefined) => {
+      if (!slug) {
+        return;
+      }
+
+      router.push(`/${slug}`);
+    },
+    [router],
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (results.length === 0) {
+      return;
+    }
+
+    const first = results[0]?.additive;
+
+    if (first) {
+      navigateToAdditive(first.slug);
+    }
+  }, [navigateToAdditive, results]);
+
+  return (
+    <Box className="header-search" data-active={query.trim().length > 0 || lastSearchQuery.length > 0 ? 'true' : undefined}>
+      <AdditiveLookup
+        additives={additives}
+        value={value}
+        onChange={(nextValue) => {
+          if (nextValue) {
+            navigateToAdditive(nextValue.slug);
+          }
+          setValue(null);
+        }}
+        placeholder="Search additives"
+        label="Search additives"
+        clearOnSelect
+        onInputValueChange={setQuery}
+        onResultsChange={(nextResults, searchQuery) => {
+          setResults(nextResults);
+          setLastSearchQuery(searchQuery);
+        }}
+        textFieldProps={{
+          size: 'small',
+          onKeyDown: (event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              if (lastSearchQuery.trim().length > 0) {
+                handleSubmit();
+              }
+            }
+          },
+          autoComplete: 'off',
+        }}
+      />
+    </Box>
+  );
+}

--- a/components/HeaderSearch.tsx
+++ b/components/HeaderSearch.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Box } from '@mui/material';
+import { Box, InputAdornment } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 
 import type { Additive } from '../lib/additives';
 import type { AdditiveSearchMatch } from '../lib/additive-search';
@@ -72,6 +73,13 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
             }
           },
           autoComplete: 'off',
+          InputProps: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          },
         }}
       />
     </Box>

--- a/components/HeaderSearch.tsx
+++ b/components/HeaderSearch.tsx
@@ -80,6 +80,15 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
           autoComplete: 'off',
           onFocus: () => setIsFocused(true),
           onBlur: () => setIsFocused(false),
+          sx: {
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 999,
+            },
+            '& .MuiOutlinedInput-input': {
+              paddingTop: 0.5,
+              paddingBottom: 0.5,
+            },
+          },
           InputProps: {
             startAdornment: (
               <InputAdornment position="start">

--- a/components/HeaderSearch.tsx
+++ b/components/HeaderSearch.tsx
@@ -18,7 +18,7 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
   const [value, setValue] = useState<Additive | null>(null);
   const [results, setResults] = useState<AdditiveSearchMatch<Additive>[]>([]);
   const [query, setQuery] = useState('');
-  const [lastSearchQuery, setLastSearchQuery] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
 
   const navigateToAdditive = useCallback(
     (slug: string | null | undefined) => {
@@ -43,8 +43,11 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
     }
   }, [navigateToAdditive, results]);
 
+  const normalizedQuery = query.trim();
+  const placeholder = !isFocused && normalizedQuery.length === 0 ? 'Search' : undefined;
+
   return (
-    <Box className="header-search" data-active={query.trim().length > 0 || lastSearchQuery.length > 0 ? 'true' : undefined}>
+    <Box className="header-search" data-active={isFocused || normalizedQuery.length > 0 ? 'true' : undefined}>
       <AdditiveLookup
         additives={additives}
         value={value}
@@ -54,25 +57,29 @@ export function HeaderSearch({ additives }: HeaderSearchProps) {
           }
           setValue(null);
         }}
-        placeholder="Search additives"
-        label="Search additives"
+        placeholder={placeholder}
         clearOnSelect
         onInputValueChange={setQuery}
         onResultsChange={(nextResults, searchQuery) => {
           setResults(nextResults);
-          setLastSearchQuery(searchQuery);
+          if (searchQuery.length === 0) {
+            setQuery('');
+          }
         }}
+        showPopupIcon={false}
         textFieldProps={{
           size: 'small',
           onKeyDown: (event) => {
             if (event.key === 'Enter') {
               event.preventDefault();
-              if (lastSearchQuery.trim().length > 0) {
+              if (normalizedQuery.length > 0) {
                 handleSubmit();
               }
             }
           },
           autoComplete: 'off',
+          onFocus: () => setIsFocused(true),
+          onBlur: () => setIsFocused(false),
           InputProps: {
             startAdornment: (
               <InputAdornment position="start">

--- a/lib/additive-search.ts
+++ b/lib/additive-search.ts
@@ -1,0 +1,148 @@
+import type { Additive } from './additives';
+
+export interface HighlightRange {
+  start: number;
+  end: number;
+}
+
+export interface SynonymMatch {
+  value: string;
+  ranges: HighlightRange[];
+  index: number;
+}
+
+export interface AdditiveSearchMatch<TAdditive extends Additive = Additive> {
+  additive: TAdditive;
+  matches: {
+    eNumber: HighlightRange[];
+    title: HighlightRange[];
+    synonym?: SynonymMatch;
+  };
+  priority: number;
+  index: number;
+}
+
+const findMatches = (source: string, query: string): HighlightRange[] => {
+  const normalizedSource = source.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+
+  if (!normalizedQuery || !normalizedSource.includes(normalizedQuery)) {
+    return [];
+  }
+
+  const ranges: HighlightRange[] = [];
+  let searchIndex = 0;
+
+  while (searchIndex <= normalizedSource.length) {
+    const matchIndex = normalizedSource.indexOf(normalizedQuery, searchIndex);
+
+    if (matchIndex === -1) {
+      break;
+    }
+
+    ranges.push({
+      start: matchIndex,
+      end: matchIndex + normalizedQuery.length,
+    });
+
+    searchIndex = matchIndex + normalizedQuery.length;
+  }
+
+  return ranges;
+};
+
+const sanitize = (value: string): string => value.normalize('NFKC');
+
+export interface SearchAdditivesOptions {
+  maxResults?: number;
+}
+
+export const searchAdditives = <TAdditive extends Additive>(
+  additives: TAdditive[],
+  rawQuery: string,
+  { maxResults }: SearchAdditivesOptions = {},
+): AdditiveSearchMatch<TAdditive>[] => {
+  const trimmed = rawQuery.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  const query = sanitize(trimmed).toLowerCase();
+  const matches: AdditiveSearchMatch<TAdditive>[] = [];
+
+  additives.forEach((additive, index) => {
+    const eNumber = sanitize(additive.eNumber ?? '');
+    const title = sanitize(additive.title ?? '');
+    const synonyms = Array.isArray(additive.synonyms) ? additive.synonyms : [];
+
+    const eNumberMatches = findMatches(eNumber, query);
+    const titleMatches = findMatches(title, query);
+
+    let synonymMatch: SynonymMatch | undefined;
+
+    for (let synonymIndex = 0; synonymIndex < synonyms.length; synonymIndex += 1) {
+      const synonym = sanitize(String(synonyms[synonymIndex] ?? ''));
+      const synonymRanges = findMatches(synonym, query);
+
+      if (synonymRanges.length > 0) {
+        synonymMatch = {
+          value: synonym,
+          ranges: synonymRanges,
+          index: synonymIndex,
+        };
+        break;
+      }
+    }
+
+    if (eNumberMatches.length === 0 && titleMatches.length === 0 && !synonymMatch) {
+      return;
+    }
+
+    const priority = eNumberMatches.length > 0 ? 0 : titleMatches.length > 0 ? 1 : 2;
+
+    matches.push({
+      additive,
+      matches: {
+        eNumber: eNumberMatches,
+        title: titleMatches,
+        synonym: synonymMatch,
+      },
+      priority,
+      index,
+    });
+  });
+
+  matches.sort((a, b) => {
+    if (a.priority !== b.priority) {
+      return a.priority - b.priority;
+    }
+
+    const aRank = typeof a.additive.searchRank === 'number' ? a.additive.searchRank : null;
+    const bRank = typeof b.additive.searchRank === 'number' ? b.additive.searchRank : null;
+
+    if (aRank !== null && bRank !== null && aRank !== bRank) {
+      return aRank - bRank;
+    }
+
+    if (aRank !== null) {
+      return -1;
+    }
+
+    if (bRank !== null) {
+      return 1;
+    }
+
+    if (a.index !== b.index) {
+      return a.index - b.index;
+    }
+
+    return a.additive.title.localeCompare(b.additive.title);
+  });
+
+  if (typeof maxResults === 'number' && Number.isFinite(maxResults) && maxResults > 0) {
+    return matches.slice(0, maxResults);
+  }
+
+  return matches;
+};

--- a/lib/additive-search.ts
+++ b/lib/additive-search.ts
@@ -5,20 +5,20 @@ export interface HighlightRange {
   end: number;
 }
 
-export interface SynonymMatch {
-  value: string;
-  ranges: HighlightRange[];
-  index: number;
-}
-
 export interface AdditiveSearchMatch<TAdditive extends Additive = Additive> {
   additive: TAdditive;
   matches: {
     eNumber: HighlightRange[];
     title: HighlightRange[];
-    synonym?: SynonymMatch;
+    synonyms: SynonymMatch[];
   };
   priority: number;
+  index: number;
+}
+
+export interface SynonymMatch {
+  value: string;
+  ranges: HighlightRange[];
   index: number;
 }
 
@@ -79,23 +79,22 @@ export const searchAdditives = <TAdditive extends Additive>(
     const eNumberMatches = findMatches(eNumber, query);
     const titleMatches = findMatches(title, query);
 
-    let synonymMatch: SynonymMatch | undefined;
+    const synonymMatches: SynonymMatch[] = [];
 
     for (let synonymIndex = 0; synonymIndex < synonyms.length; synonymIndex += 1) {
       const synonym = sanitize(String(synonyms[synonymIndex] ?? ''));
       const synonymRanges = findMatches(synonym, query);
 
       if (synonymRanges.length > 0) {
-        synonymMatch = {
+        synonymMatches.push({
           value: synonym,
           ranges: synonymRanges,
           index: synonymIndex,
-        };
-        break;
+        });
       }
     }
 
-    if (eNumberMatches.length === 0 && titleMatches.length === 0 && !synonymMatch) {
+    if (eNumberMatches.length === 0 && titleMatches.length === 0 && synonymMatches.length === 0) {
       return;
     }
 
@@ -106,7 +105,7 @@ export const searchAdditives = <TAdditive extends Additive>(
       matches: {
         eNumber: eNumberMatches,
         title: titleMatches,
-        synonym: synonymMatch,
+        synonyms: synonymMatches,
       },
       priority,
       index,

--- a/lib/additive-search.ts
+++ b/lib/additive-search.ts
@@ -64,7 +64,7 @@ export const searchAdditives = <TAdditive extends Additive>(
 ): AdditiveSearchMatch<TAdditive>[] => {
   const trimmed = rawQuery.trim();
 
-  if (!trimmed) {
+  if (trimmed.length < 2) {
     return [];
   }
 


### PR DESCRIPTION
## Summary
- extract reusable additive lookup logic with substring highlighting and synonym support
- reuse the lookup component on the compare page
- add a responsive header search widget that navigates directly to additive detail pages

## Testing
- npm run lint
- CI=1 NO_COLOR=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e496a1242483279a5fe71e3db2f2ab