### PR TITLE
Add additive parent-child data script and UI support [archived]

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -61,6 +61,10 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
   }
 
   const synonymList = additive.synonyms.filter((value, index, list) => list.indexOf(value) === index);
+  const parentRelations = additive.parents;
+  const childRelations = additive.children;
+  const hasParents = parentRelations.length > 0;
+  const hasChildren = childRelations.length > 0;
   const searchHistory = getSearchHistory(additive.slug);
   const searchHistoryKeywords = searchHistory?.keywords ?? [];
   const hasSearchHistory =
@@ -115,6 +119,32 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
     searchCountryLabel ?? (searchCountryCode ? searchCountryCode.trim().toUpperCase() : null);
   const productCount = typeof additive.productCount === 'number' ? additive.productCount : null;
   const productSearchUrl = `https://us.openfoodfacts.org/facets/additives/${additive.slug}`;
+  const renderRelationLinks = (relations: typeof parentRelations) =>
+    relations.map((relation) => {
+      const label = formatAdditiveDisplayName(relation.eNumber, relation.title);
+
+      return (
+        <Box
+          component="span"
+          key={relation.slug}
+          sx={{
+            display: 'inline-block',
+            '&:not(:last-of-type)::after': {
+              content: '", "',
+            },
+          }}
+        >
+          <MuiLink
+            component={NextLink}
+            href={`/${relation.slug}`}
+            underline="hover"
+            sx={{ fontWeight: 500 }}
+          >
+            {label}
+          </MuiLink>
+        </Box>
+      );
+    });
   const articleSummary = extractArticleSummary(additive.article);
   const articleBody = extractArticleBody(additive.article);
   const originList = additive.origin.filter((value, index, list) => list.indexOf(value) === index);
@@ -202,6 +232,22 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
                   {synonym}
                 </Box>
               ))}
+            </Typography>
+          )}
+          {hasParents && (
+            <Typography variant="body1" color="text.secondary">
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Belongs to:
+              </Box>{' '}
+              {renderRelationLinks(parentRelations)}
+            </Typography>
+          )}
+          {hasChildren && (
+            <Typography variant="body1" color="text.secondary">
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Contains:
+              </Box>{' '}
+              {renderRelationLinks(childRelations)}
             </Typography>
           )}
           {(searchRank !== null || searchVolume !== null || searchCountryText || hasKeywordShare) && (

--- a/app/function/[functionSlug]/page.tsx
+++ b/app/function/[functionSlug]/page.tsx
@@ -3,11 +3,13 @@ import { notFound } from 'next/navigation';
 import { Box, Typography } from '@mui/material';
 
 import {
+  filterAdditivesByClassVisibility,
   getAdditivesByFunctionSlug,
   getFunctionFilters,
   getOriginFilters,
   getFunctionValueBySlug,
   parseAdditiveSortMode,
+  parseShowClassesParam,
   sortAdditivesByMode,
 } from '../../../lib/additives';
 import { formatFilterLabel } from '../../../lib/text';
@@ -16,7 +18,7 @@ import { FilterPanel } from '../../../components/FilterPanel';
 
 interface FunctionPageProps {
   params: Promise<{ functionSlug: string }>;
-  searchParams?: Promise<{ sort?: string | string[] }>;
+  searchParams?: Promise<{ sort?: string | string[]; classes?: string | string[] }>;
 }
 
 const formatCountLabel = (count: number): string =>
@@ -70,7 +72,9 @@ export default async function FunctionPage({ params, searchParams }: FunctionPag
   const additives = getAdditivesByFunctionSlug(functionSlug);
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const sortMode = parseAdditiveSortMode(resolvedSearchParams?.sort ?? null);
+  const showClasses = parseShowClassesParam(resolvedSearchParams?.classes ?? null);
   const sortedAdditives = sortAdditivesByMode(additives, sortMode);
+  const visibleAdditives = filterAdditivesByClassVisibility(sortedAdditives, showClasses);
   const label = formatFilterLabel(functionValue);
 
   return (
@@ -89,9 +93,10 @@ export default async function FunctionPage({ params, searchParams }: FunctionPag
         originOptions={originOptions}
         currentFunctionSlug={functionSlug}
         currentSortMode={sortMode}
+        currentShowClasses={showClasses}
       />
       <AdditiveGrid
-        items={sortedAdditives}
+        items={visibleAdditives}
         sortMode={sortMode}
         emptyMessage="No additives found for this function."
       />

--- a/app/origin/[originSlug]/page.tsx
+++ b/app/origin/[originSlug]/page.tsx
@@ -3,11 +3,13 @@ import { notFound } from 'next/navigation';
 import { Box, Typography } from '@mui/material';
 
 import {
+  filterAdditivesByClassVisibility,
   getAdditivesByOriginSlug,
   getFunctionFilters,
   getOriginFilters,
   getOriginValueBySlug,
   parseAdditiveSortMode,
+  parseShowClassesParam,
   sortAdditivesByMode,
 } from '../../../lib/additives';
 import { formatFilterLabel } from '../../../lib/text';
@@ -16,7 +18,7 @@ import { FilterPanel } from '../../../components/FilterPanel';
 
 interface OriginPageProps {
   params: Promise<{ originSlug: string }>;
-  searchParams?: Promise<{ sort?: string | string[] }>;
+  searchParams?: Promise<{ sort?: string | string[]; classes?: string | string[] }>;
 }
 
 const formatCountLabel = (count: number): string =>
@@ -70,7 +72,9 @@ export default async function OriginPage({ params, searchParams }: OriginPagePro
   const additives = getAdditivesByOriginSlug(originSlug);
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const sortMode = parseAdditiveSortMode(resolvedSearchParams?.sort ?? null);
+  const showClasses = parseShowClassesParam(resolvedSearchParams?.classes ?? null);
   const sortedAdditives = sortAdditivesByMode(additives, sortMode);
+  const visibleAdditives = filterAdditivesByClassVisibility(sortedAdditives, showClasses);
   const label = formatFilterLabel(originValue);
 
   return (
@@ -89,9 +93,10 @@ export default async function OriginPage({ params, searchParams }: OriginPagePro
         originOptions={originOptions}
         currentOriginSlug={originSlug}
         currentSortMode={sortMode}
+        currentShowClasses={showClasses}
       />
       <AdditiveGrid
-        items={sortedAdditives}
+        items={visibleAdditives}
         sortMode={sortMode}
         emptyMessage="No additives found for this origin."
       />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,10 +3,12 @@ import { Box, Typography } from '@mui/material';
 import { AdditiveGrid } from '../components/AdditiveGrid';
 import { FilterPanel } from '../components/FilterPanel';
 import {
+  filterAdditivesByClassVisibility,
   getAdditives,
   getFunctionFilters,
   getOriginFilters,
   parseAdditiveSortMode,
+  parseShowClassesParam,
   sortAdditivesByMode,
 } from '../lib/additives';
 import { formatFilterLabel } from '../lib/text';
@@ -22,13 +24,15 @@ const originOptions = getOriginFilters().map(({ slug, value }) => ({
 }));
 
 interface HomePageProps {
-  searchParams?: Promise<{ sort?: string | string[] }>;
+  searchParams?: Promise<{ sort?: string | string[]; classes?: string | string[] }>;
 }
 
 export default async function HomePage({ searchParams }: HomePageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const sortMode = parseAdditiveSortMode(resolvedSearchParams?.sort ?? null);
+  const showClasses = parseShowClassesParam(resolvedSearchParams?.classes ?? null);
   const sortedAdditives = sortAdditivesByMode(additives, sortMode);
+  const visibleAdditives = filterAdditivesByClassVisibility(sortedAdditives, showClasses);
 
   return (
     <Box component="section" display="flex" flexDirection="column" gap={4}>
@@ -46,8 +50,9 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         functionOptions={functionOptions}
         originOptions={originOptions}
         currentSortMode={sortMode}
+        currentShowClasses={showClasses}
       />
-      <AdditiveGrid items={sortedAdditives} sortMode={sortMode} />
+      <AdditiveGrid items={visibleAdditives} sortMode={sortMode} />
     </Box>
   );
 }

--- a/components/FilterPanel.tsx
+++ b/components/FilterPanel.tsx
@@ -1,8 +1,16 @@
 'use client';
 
-import { useTransition } from 'react';
+import { useTransition, ChangeEvent } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material';
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+} from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
 
 import type { AdditiveSortMode } from '../lib/additives';
@@ -18,9 +26,11 @@ interface FilterPanelProps {
   currentFunctionSlug?: string | null;
   currentOriginSlug?: string | null;
   currentSortMode?: AdditiveSortMode;
+  currentShowClasses?: boolean;
 }
 
 const HOME_ROUTE = '/';
+const SHOW_CLASSES_PARAM = 'classes';
 
 export function FilterPanel({
   functionOptions,
@@ -28,6 +38,7 @@ export function FilterPanel({
   currentFunctionSlug = null,
   currentOriginSlug = null,
   currentSortMode = 'search-rank',
+  currentShowClasses = false,
 }: FilterPanelProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -43,6 +54,12 @@ export function FilterPanel({
       params.set('sort', 'products');
     } else {
       params.delete('sort');
+    }
+
+    if (currentShowClasses) {
+      params.set(SHOW_CLASSES_PARAM, '1');
+    } else {
+      params.delete(SHOW_CLASSES_PARAM);
     }
 
     const queryString = params.toString();
@@ -81,6 +98,29 @@ export function FilterPanel({
     });
   };
 
+  const handleShowClassesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked;
+
+    startTransition(() => {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+
+      if (checked) {
+        params.set(SHOW_CLASSES_PARAM, '1');
+      } else {
+        params.delete(SHOW_CLASSES_PARAM);
+      }
+
+      if (currentSortValue === 'products') {
+        params.set('sort', 'products');
+      } else {
+        params.delete('sort');
+      }
+
+      const queryString = params.toString();
+      router.push(queryString ? `${pathname}?${queryString}` : pathname);
+    });
+  };
+
   return (
     <Stack
       direction={{ xs: 'column', sm: 'row' }}
@@ -90,6 +130,19 @@ export function FilterPanel({
       width="100%"
       flexWrap="wrap"
     >
+      <FormControlLabel
+        control={
+          <Checkbox
+            size="small"
+            checked={currentShowClasses}
+            onChange={handleShowClassesChange}
+            disabled={isPending}
+          />
+        }
+        label="Show classes"
+        sx={{ margin: 0 }}
+      />
+
       <FormControl
         size="small"
         sx={{ minWidth: { xs: '100%', sm: 180 } }}

--- a/data/e339-sodium-phosphates/props.json
+++ b/data/e339-sodium-phosphates/props.json
@@ -21,5 +21,9 @@
     "artificial",
     "mineral"
   ],
-  "productCount": 1968
+  "productCount": 1968,
+  "children": [
+    "en:e339i",
+    "en:e339iii"
+  ]
 }

--- a/data/e339i-monosodium-phosphate/props.json
+++ b/data/e339i-monosodium-phosphate/props.json
@@ -24,5 +24,8 @@
     "synthetic",
     "mineral"
   ],
-  "productCount": 126
+  "productCount": 126,
+  "parents": [
+    "en:e339"
+  ]
 }

--- a/data/e339iii-trisodium-phosphate/props.json
+++ b/data/e339iii-trisodium-phosphate/props.json
@@ -20,5 +20,8 @@
   "origin": [
     "synthetic"
   ],
-  "productCount": 1058
+  "productCount": 1058,
+  "parents": [
+    "en:e339"
+  ]
 }

--- a/lib/additive-slug.ts
+++ b/lib/additive-slug.ts
@@ -17,7 +17,7 @@ const slugifySegment = (value: string | undefined | null): string => {
     .replace(/(^-|-$)/g, '');
 };
 
-const normaliseENumber = (value: string | undefined | null): string => {
+export const normaliseENumber = (value: string | undefined | null): string => {
   if (!value) {
     return '';
   }

--- a/scripts/update-additives-from-OFF.js
+++ b/scripts/update-additives-from-OFF.js
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+
+/**
+ * Updates parent/child relationships for additives using the
+ * Open Food Facts taxonomy API.
+ *
+ * Usage mirrors the other data scripts in this project. Run with
+ * `--help` to view the available options.
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const { createAdditiveSlug, normaliseENumber } = require('./utils/slug');
+
+const execFileAsync = promisify(execFile);
+
+const TAXONOMY_BASE_URL =
+  'https://us.openfoodfacts.org/api/v2/taxonomy?tagtype=additives&tags=';
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const ADDITIVES_INDEX_PATH = path.join(DATA_DIR, 'additives.json');
+const DEFAULT_PARALLEL = 5;
+const MAX_FETCH_ATTEMPTS = 3;
+const REQUEST_DELAY_MS = 150;
+
+let DEBUG = false;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const debugLog = (...args) => {
+  if (DEBUG) {
+    console.log(...args);
+  }
+};
+
+const parsePositiveInteger = (value, label) => {
+  const parsed = Number.parseInt(String(value), 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid value for ${label}: ${value}`);
+  }
+
+  return parsed;
+};
+
+const parseArgs = (argv) => {
+  const result = {
+    additiveSlugs: [],
+    limit: null,
+    parallel: null,
+    debug: false,
+    help: false,
+    override: false,
+  };
+
+  const args = Array.isArray(argv) ? argv.slice(2) : [];
+  let index = 0;
+
+  while (index < args.length) {
+    const arg = args[index];
+
+    if (arg === '--help' || arg === '-h' || arg === '-help') {
+      result.help = true;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--debug' || arg === '-d') {
+      result.debug = true;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--override' || arg === '--overide' || arg === '--force') {
+      result.override = true;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--limit' || arg === '-n' || arg === '-limit') {
+      if (index + 1 >= args.length) {
+        throw new Error('Missing value for --limit.');
+      }
+      result.limit = parsePositiveInteger(args[index + 1], '--limit');
+      index += 2;
+      continue;
+    }
+
+    if (arg.startsWith('--limit=')) {
+      const value = arg.substring(arg.indexOf('=') + 1);
+      result.limit = parsePositiveInteger(value, '--limit');
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--parallel' || arg === '--batch' || arg === '-p') {
+      if (index + 1 >= args.length) {
+        throw new Error('Missing value for --parallel.');
+      }
+      result.parallel = parsePositiveInteger(args[index + 1], '--parallel');
+      index += 2;
+      continue;
+    }
+
+    if (arg.startsWith('--parallel=') || arg.startsWith('--batch=')) {
+      const value = arg.substring(arg.indexOf('=') + 1);
+      result.parallel = parsePositiveInteger(value, '--parallel');
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--additive' || arg === '-a') {
+      const values = [];
+      let cursor = index + 1;
+
+      while (cursor < args.length && !args[cursor].startsWith('-')) {
+        values.push(args[cursor]);
+        cursor += 1;
+      }
+
+      if (values.length === 0) {
+        throw new Error('No additive slugs supplied after --additive.');
+      }
+
+      result.additiveSlugs.push(
+        ...values.map((value) => value.trim().toLowerCase()).filter(Boolean),
+      );
+      index = cursor;
+      continue;
+    }
+
+    if (arg.startsWith('--additive=')) {
+      const value = arg.substring(arg.indexOf('=') + 1);
+
+      if (!value) {
+        throw new Error('No additive slug supplied after --additive=.');
+      }
+
+      const parts = value
+        .split(',')
+        .map((entry) => entry.trim().toLowerCase())
+        .filter(Boolean);
+
+      if (parts.length === 0) {
+        throw new Error('No additive slug supplied after --additive=.');
+      }
+
+      result.additiveSlugs.push(...parts);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    result.additiveSlugs.push(arg.trim().toLowerCase());
+    index += 1;
+  }
+
+  result.additiveSlugs = result.additiveSlugs.filter(Boolean);
+
+  return result;
+};
+
+const printUsage = () => {
+  console.log(`Usage: node scripts/update-additives-from-OFF.js [options]\n\n`);
+  console.log('Options:');
+  console.log('  --additive <slug...>      Process only the specified additive slugs.');
+  console.log('  --limit <n>               Process at most n additives.');
+  console.log('  --parallel <n>            Maximum number of concurrent requests.');
+  console.log('  --override                Refresh additives even if local data exists.');
+  console.log('  --debug                   Enable verbose logging.');
+  console.log('  --help                    Show this help message.');
+};
+
+const fileExists = async (filePath) => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const readAdditiveIndex = async () => {
+  const raw = await fs.readFile(ADDITIVES_INDEX_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  if (!Array.isArray(parsed.additives)) {
+    throw new Error('Invalid additives index: missing `additives` array.');
+  }
+
+  return parsed.additives.map((entry) => {
+    const title = typeof entry?.title === 'string' ? entry.title : '';
+    const eNumber = typeof entry?.eNumber === 'string' ? entry.eNumber : '';
+    const slug = createAdditiveSlug({ eNumber, title });
+
+    return { slug, title, eNumber };
+  });
+};
+
+const normaliseRelationTag = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  const lower = trimmed.toLowerCase();
+  const segments = lower.split(':').filter(Boolean);
+
+  if (segments.length === 0) {
+    return '';
+  }
+
+  if (segments.length === 1) {
+    return `en:${segments[0]}`;
+  }
+
+  const suffix = segments.pop();
+  const prefix = segments.shift();
+
+  if (!suffix) {
+    return '';
+  }
+
+  return `${prefix || 'en'}:${suffix}`;
+};
+
+const toSortedUniqueList = (values) => {
+  const unique = new Set();
+
+  values.forEach((value) => {
+    const normalised = normaliseRelationTag(value);
+
+    if (normalised) {
+      unique.add(normalised);
+    }
+  });
+
+  return Array.from(unique.values()).sort((a, b) => a.localeCompare(b));
+};
+
+const normaliseStoredRelationList = (value) => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return toSortedUniqueList(value);
+};
+
+const arraysEqual = (a, b) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const fetchJson = async (url, description) => {
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync('curl', ['-fsS', url]);
+      return JSON.parse(stdout);
+    } catch (error) {
+      const isLastAttempt = attempt === MAX_FETCH_ATTEMPTS;
+      console.error(
+        `Failed to fetch ${description} (attempt ${attempt}): ${error.message}`,
+      );
+      if (isLastAttempt) {
+        throw error;
+      }
+      await sleep(REQUEST_DELAY_MS * attempt);
+    }
+  }
+
+  throw new Error(`Unable to fetch ${description}`);
+};
+
+const extractTaxonomyNode = (response) => {
+  if (!response || typeof response !== 'object') {
+    return null;
+  }
+
+  const entries = Object.values(response).filter(
+    (entry) => entry && typeof entry === 'object',
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return entries[0];
+};
+
+const extractRelations = (node) => {
+  if (!node || typeof node !== 'object') {
+    return { parents: [], children: [] };
+  }
+
+  const children = Array.isArray(node.children) ? node.children : [];
+  const parents = Array.isArray(node.parents) ? node.parents : [];
+
+  return {
+    children: toSortedUniqueList(children),
+    parents: toSortedUniqueList(parents),
+  };
+};
+
+const processAdditive = async ({ slug, eNumber, title }, { targeted }) => {
+  const propsPath = path.join(DATA_DIR, slug, 'props.json');
+
+  if (!(await fileExists(propsPath))) {
+    console.warn(`Skipping ${slug}: props.json not found.`);
+    return { slug, skipped: true };
+  }
+
+  const normalisedENumber = normaliseENumber(eNumber);
+
+  if (!normalisedENumber) {
+    console.warn(`Skipping ${slug}: missing valid E-number.`);
+    return { slug, skipped: true };
+  }
+
+  const rawProps = await fs.readFile(propsPath, 'utf8');
+  const props = JSON.parse(rawProps);
+  const existingChildren = normaliseStoredRelationList(props.children);
+  const existingParents = normaliseStoredRelationList(props.parents);
+
+  if (!targeted && (existingChildren.length > 0 || existingParents.length > 0)) {
+    debugLog(`Skipping ${slug}: relationships already populated.`);
+    return { slug, skipped: true };
+  }
+
+  const requestUrl = `${TAXONOMY_BASE_URL}en:${normalisedENumber}`;
+  debugLog(`Fetching taxonomy for ${slug} (${title}) from ${requestUrl}`);
+  const response = await fetchJson(requestUrl, `taxonomy for ${slug}`);
+  const node = extractTaxonomyNode(response);
+
+  if (!node) {
+    console.warn(`No taxonomy node returned for ${slug} (${normalisedENumber}).`);
+    return { slug, skipped: true };
+  }
+
+  const { children, parents } = extractRelations(node);
+  const hasRelations = children.length > 0 || parents.length > 0;
+
+  if (!hasRelations) {
+    if (existingChildren.length === 0 && existingParents.length === 0) {
+      debugLog(`No parent/child relationships found for ${slug}.`);
+      return { slug, skipped: true };
+    }
+  }
+
+  let updated = false;
+
+  if (children.length > 0) {
+    if (!arraysEqual(children, existingChildren)) {
+      props.children = children;
+      updated = true;
+    }
+  } else if (props.children) {
+    delete props.children;
+    updated = true;
+  }
+
+  if (parents.length > 0) {
+    if (!arraysEqual(parents, existingParents)) {
+      props.parents = parents;
+      updated = true;
+    }
+  } else if (props.parents) {
+    delete props.parents;
+    updated = true;
+  }
+
+  if (!updated) {
+    debugLog(`No changes required for ${slug}.`);
+    return { slug, skipped: true };
+  }
+
+  const output = `${JSON.stringify(props, null, 2)}\n`;
+  await fs.writeFile(propsPath, output, 'utf8');
+
+  debugLog(
+    `Updated ${slug}: parents=${parents.length}, children=${children.length} -> ${propsPath}`,
+  );
+
+  return { slug, updated: true, parents: parents.length, children: children.length };
+};
+
+const runWithConcurrency = async (items, parallel, handler) => {
+  const results = [];
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      try {
+        const result = await handler(items[index], index);
+        results[index] = result;
+      } catch (error) {
+        results[index] = { error };
+      }
+      if (REQUEST_DELAY_MS > 0) {
+        await sleep(REQUEST_DELAY_MS);
+      }
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(parallel, items.length) }, worker);
+  await Promise.all(workers);
+
+  return results;
+};
+
+(async () => {
+  try {
+    const args = parseArgs(process.argv);
+
+    if (args.help) {
+      printUsage();
+      return;
+    }
+
+    DEBUG = args.debug;
+
+    const indexEntries = await readAdditiveIndex();
+    const slugMap = new Map(indexEntries.map((entry) => [entry.slug, entry]));
+
+    let targets = [];
+
+    if (args.additiveSlugs.length > 0) {
+      targets = args.additiveSlugs
+        .map((slug) => {
+          const entry = slugMap.get(slug);
+
+          if (!entry) {
+            console.warn(`Unknown additive slug: ${slug}`);
+          }
+
+          return entry || null;
+        })
+        .filter(Boolean);
+
+      if (targets.length === 0) {
+        console.error('No valid additive slugs supplied.');
+        process.exitCode = 1;
+        return;
+      }
+    } else {
+      targets = [...indexEntries];
+
+      if (typeof args.limit === 'number') {
+        targets = targets.slice(0, args.limit);
+      }
+    }
+
+    if (targets.length === 0) {
+      console.log('No additives to process.');
+      return;
+    }
+
+    const parallel = args.parallel || DEFAULT_PARALLEL;
+    const targetedMode = args.additiveSlugs.length > 0;
+
+    console.log(
+      `Processing ${targets.length} additive${targets.length === 1 ? '' : 's'} (${parallel} concurrent).`,
+    );
+
+    const results = await runWithConcurrency(targets, parallel, (item) =>
+      processAdditive(item, { targeted: targetedMode || args.override }),
+    );
+
+    let updatedCount = 0;
+    let skippedCount = 0;
+    let errorCount = 0;
+
+    results.forEach((result, index) => {
+      if (!result) {
+        errorCount += 1;
+        console.error(`Unknown error while processing ${targets[index].slug}.`);
+        return;
+      }
+
+      if (result.error) {
+        errorCount += 1;
+        console.error(
+          `Failed to process ${targets[index].slug}: ${result.error.message}`,
+        );
+        return;
+      }
+
+      if (result.updated) {
+        updatedCount += 1;
+        console.log(
+          `Updated ${targets[index].slug}: parents=${result.parents ?? 0}, children=${result.children ?? 0}`,
+        );
+      } else {
+        skippedCount += 1;
+      }
+    });
+
+    console.log(
+      `Done. Updated ${updatedCount}, skipped ${skippedCount}, errors ${errorCount}.`,
+    );
+
+    if (errorCount > 0) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error('Fatal error:', error);
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a data refresh script that pulls parent/child relationships for additives from OFF and updates props files
- surface parent and child links on additive detail pages and expose the data via the additive loader
- add a “Show classes” checkbox to hide class-level additives in the catalogue by default

## Testing
- npm run lint
- CI=1 npm run build
- node scripts/update-additives-from-OFF.js --additive e339-sodium-phosphates e339i-monosodium-phosphate e339iii-trisodium-phosphate --debug

------
https://chatgpt.com/codex/tasks/task_b_68eace3213f48327897181ab7b09ade2