### PR TITLE
Add cached additives API and client-side sorting fetch

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -28,6 +28,7 @@ import { CopyLinkButton } from '../../components/CopyLinkButton';
 import { FunctionFilterChipList } from '../../components/FunctionFilterChipList';
 import { OriginChipList } from '../../components/OriginChipList';
 import { trimDescription, trimTitle } from '../../lib/seo';
+import { getAwarenessLevel } from '../../lib/awareness';
 
 interface AdditivePageProps {
   params: Promise<{ slug: string }>;
@@ -454,6 +455,14 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
                   Awareness score:
                 </Box>
                 <AwarenessScoreChip score={awarenessScore} />
+                {(() => {
+                  const level = getAwarenessLevel(awarenessScore.index);
+                  return level ? (
+                    <Box component="span" sx={{ color: 'text.secondary' }}>
+                      {level}
+                    </Box>
+                  ) : null;
+                })()}
               </Typography>
             ) : null}
           </Box>

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -454,15 +454,26 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
                 <Box component="span" sx={{ fontWeight: 600 }}>
                   Awareness score:
                 </Box>
-                <AwarenessScoreChip score={awarenessScore} />
-                {(() => {
-                  const level = getAwarenessLevel(awarenessScore.index);
-                  return level ? (
-                    <Box component="span" sx={{ color: 'text.secondary' }}>
-                      {level}
-                    </Box>
-                  ) : null;
-                })()}
+                <Box
+                  component="span"
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    flexWrap: 'nowrap',
+                    minHeight: 32,
+                  }}
+                >
+                  <AwarenessScoreChip score={awarenessScore} />
+                  {(() => {
+                    const level = getAwarenessLevel(awarenessScore.index);
+                    return level ? (
+                      <Box component="span" sx={{ color: 'text.secondary', whiteSpace: 'nowrap' }}>
+                        {level}
+                      </Box>
+                    ) : null;
+                  })()}
+                </Box>
               </Typography>
             ) : null}
           </Box>

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -247,6 +247,13 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
     lineHeight: 1.8,
   } as const;
 
+  const awarenessRowSx = {
+    ...detailRowTypographySx,
+    flexWrap: 'nowrap',
+    columnGap: 1.25,
+    minHeight: 32,
+  } as const;
+
   return (
     <>
       <CompareFlapPrefill slug={additive.slug} />
@@ -450,7 +457,7 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
               </Typography>
             )}
             {awarenessScore ? (
-              <Typography variant="body1" color="text.secondary" sx={detailRowTypographySx}>
+              <Typography variant="body1" color="text.secondary" sx={awarenessRowSx}>
                 <Box component="span" sx={{ fontWeight: 600 }}>
                   Awareness score:
                 </Box>
@@ -461,7 +468,6 @@ export default async function AdditivePage({ params }: AdditivePageProps) {
                     alignItems: 'center',
                     gap: 1,
                     flexWrap: 'nowrap',
-                    minHeight: 32,
                   }}
                 >
                   <AwarenessScoreChip score={awarenessScore} />

--- a/src/app/api/additives/route.ts
+++ b/src/app/api/additives/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+
+import {
+  type AdditiveSortMode,
+  parseAdditiveSortMode,
+  parseShowClassesParam,
+} from '../../../lib/additives';
+import { loadAdditivesBatch } from '../../actions/additives';
+
+export const revalidate = 604800; // 7 days
+
+const toSafeOffset = (value: string | null): number => {
+  const parsed = value ? Number.parseInt(value, 10) : 0;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const API_LIMIT = 100;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const sortMode: AdditiveSortMode = parseAdditiveSortMode(searchParams.get('sort'));
+  const showClasses = parseShowClassesParam(searchParams.get('classes'));
+  const offset = toSafeOffset(searchParams.get('offset'));
+  const filterType = searchParams.get('filterType');
+  const filterSlug = searchParams.get('filterSlug');
+  const filterTypeValue = filterType === 'function' || filterType === 'origin' ? filterType : null;
+  const filter = filterTypeValue && filterSlug ? ({ type: filterTypeValue, slug: filterSlug } as const) : null;
+
+  try {
+    const result = await loadAdditivesBatch({
+      offset,
+      limit: API_LIMIT,
+      sortMode,
+      showClasses,
+      filter,
+    });
+
+    return NextResponse.json(result, {
+      headers: {
+        'Cache-Control': 's-maxage=604800, stale-while-revalidate=86400',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to fetch additives batch', error);
+    return NextResponse.json(
+      { error: 'Failed to load additives' },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+}

--- a/src/app/function/[functionSlug]/page.tsx
+++ b/src/app/function/[functionSlug]/page.tsx
@@ -10,8 +10,7 @@ import {
   getOriginFilters,
   getFunctionValueBySlug,
   filterAdditivesByClassVisibility,
-  parseAdditiveSortMode,
-  parseShowClassesParam,
+  DEFAULT_ADDITIVE_SORT_MODE,
   sortAdditivesByMode,
   mapAdditivesToGridItems,
   getAwarenessScores,
@@ -19,7 +18,6 @@ import {
 import { formatFilterLabel } from '../../../lib/text';
 import { formatFunctionLabel } from '../../../lib/additive-format';
 import { getFunctionInfo, formatUsedAsList } from '../../../lib/function-details';
-import { AdditiveGrid } from '../../../components/AdditiveGrid';
 import { AdditiveGridInfinite } from '../../../components/AdditiveGridInfinite';
 import { FilterPanel } from '../../../components/FilterPanel';
 import { buildShowClassesHref } from '../../../lib/url';
@@ -31,10 +29,6 @@ const gridSocialImage = absoluteUrl('/img/grid-screenshot.png');
 
 interface FunctionPageProps {
   params: Promise<{ functionSlug: string }>;
-  searchParams?: Promise<{
-    sort?: string | string[];
-    classes?: string | string[];
-  }>;
 }
 
 const formatCountLabel = (count: number): string =>
@@ -104,7 +98,7 @@ export async function generateMetadata({ params }: FunctionPageProps): Promise<M
   };
 }
 
-export default async function FunctionPage({ params, searchParams }: FunctionPageProps) {
+export default async function FunctionPage({ params }: FunctionPageProps) {
   const { functionSlug } = await params;
   const functionValue = getFunctionValueBySlug(functionSlug);
 
@@ -113,16 +107,15 @@ export default async function FunctionPage({ params, searchParams }: FunctionPag
   }
 
   const additives = getAdditivesByFunctionSlug(functionSlug);
-  const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const sortMode = parseAdditiveSortMode(resolvedSearchParams?.sort ?? null);
-  const showClasses = parseShowClassesParam(resolvedSearchParams?.classes ?? null);
-  const filteredAdditives = filterAdditivesByClassVisibility(additives, showClasses);
-  const sortedAdditives = sortAdditivesByMode(filteredAdditives, sortMode);
+  const initialSortMode = DEFAULT_ADDITIVE_SORT_MODE;
+  const initialShowClasses = false;
+  const filteredAdditives = filterAdditivesByClassVisibility(additives, initialShowClasses);
+  const sortedAdditives = sortAdditivesByMode(filteredAdditives, initialSortMode);
   const awarenessResult = getAwarenessScores();
-  const hiddenAdditivesCount = showClasses ? 0 : additives.length - filteredAdditives.length;
-  const showHiddenCountLink = hiddenAdditivesCount > 0 && !showClasses;
+  const hiddenAdditivesCount = additives.length - filteredAdditives.length;
+  const showHiddenCountLink = hiddenAdditivesCount > 0;
   const hiddenAdditivesHref = showHiddenCountLink
-    ? buildShowClassesHref(`/function/${functionSlug}`, resolvedSearchParams)
+    ? buildShowClassesHref(`/function/${functionSlug}`, undefined)
     : null;
   const functionLabelRaw = formatFunctionLabel(functionValue);
   const functionHeading = functionLabelRaw
@@ -206,28 +199,19 @@ export default async function FunctionPage({ params, searchParams }: FunctionPag
             functionOptions={functionOptions}
             originOptions={originOptions}
             currentFilter={{ type: 'function', slug: functionSlug }}
-            currentSortMode={sortMode}
-            currentShowClasses={showClasses}
+            currentSortMode={initialSortMode}
+            currentShowClasses={initialShowClasses}
           />
         </Suspense>
-        {useInfiniteScroll ? (
-          <AdditiveGridInfinite
-            initialItems={initialItems}
-            totalCount={totalCount}
-            sortMode={sortMode}
-            showClasses={showClasses}
-            chunkSize={chunkSize}
-            filter={{ type: 'function', slug: functionSlug }}
-            awarenessScores={awarenessResult.scores}
-          />
-        ) : (
-          <AdditiveGrid
-            items={initialItems}
-            sortMode={sortMode}
-            emptyMessage="No additives found for this function."
-            awarenessScores={awarenessResult.scores}
-          />
-        )}
+        <AdditiveGridInfinite
+          initialItems={initialItems}
+          totalCount={totalCount}
+          initialSortMode={initialSortMode}
+          initialShowClasses={initialShowClasses}
+          chunkSize={chunkSize}
+          filter={{ type: 'function', slug: functionSlug }}
+          awarenessScores={awarenessResult.scores}
+        />
       </Box>
     </>
   );

--- a/src/app/origin/[originSlug]/page.tsx
+++ b/src/app/origin/[originSlug]/page.tsx
@@ -12,8 +12,7 @@ import {
   getOriginFilters,
   getOriginValueBySlug,
   filterAdditivesByClassVisibility,
-  parseAdditiveSortMode,
-  parseShowClassesParam,
+  DEFAULT_ADDITIVE_SORT_MODE,
   sortAdditivesByMode,
   mapAdditivesToGridItems,
   getAwarenessScores,
@@ -21,7 +20,6 @@ import {
 import { formatFilterLabel } from '../../../lib/text';
 import { getOriginHeroIcon } from '../../../lib/origin-icons';
 import { getOriginDescription } from '../../../lib/origins';
-import { AdditiveGrid } from '../../../components/AdditiveGrid';
 import { AdditiveGridInfinite } from '../../../components/AdditiveGridInfinite';
 import { FilterPanel } from '../../../components/FilterPanel';
 import { buildShowClassesHref } from '../../../lib/url';
@@ -33,10 +31,6 @@ const gridSocialImage = absoluteUrl('/img/grid-screenshot.png');
 
 interface OriginPageProps {
   params: Promise<{ originSlug: string }>;
-  searchParams?: Promise<{
-    sort?: string | string[];
-    classes?: string | string[];
-  }>;
 }
 
 const formatCountLabel = (count: number): string =>
@@ -106,7 +100,7 @@ export async function generateMetadata({ params }: OriginPageProps): Promise<Met
   };
 }
 
-export default async function OriginPage({ params, searchParams }: OriginPageProps) {
+export default async function OriginPage({ params }: OriginPageProps) {
   const { originSlug } = await params;
   const originValue = getOriginValueBySlug(originSlug);
 
@@ -115,16 +109,15 @@ export default async function OriginPage({ params, searchParams }: OriginPagePro
   }
 
   const additives = getAdditivesByOriginSlug(originSlug);
-  const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const sortMode = parseAdditiveSortMode(resolvedSearchParams?.sort ?? null);
-  const showClasses = parseShowClassesParam(resolvedSearchParams?.classes ?? null);
-  const filteredAdditives = filterAdditivesByClassVisibility(additives, showClasses);
-  const sortedAdditives = sortAdditivesByMode(filteredAdditives, sortMode);
+  const initialSortMode = DEFAULT_ADDITIVE_SORT_MODE;
+  const initialShowClasses = false;
+  const filteredAdditives = filterAdditivesByClassVisibility(additives, initialShowClasses);
+  const sortedAdditives = sortAdditivesByMode(filteredAdditives, initialSortMode);
   const awarenessResult = getAwarenessScores();
-  const hiddenAdditivesCount = showClasses ? 0 : additives.length - filteredAdditives.length;
-  const showHiddenCountLink = hiddenAdditivesCount > 0 && !showClasses;
+  const hiddenAdditivesCount = additives.length - filteredAdditives.length;
+  const showHiddenCountLink = hiddenAdditivesCount > 0;
   const hiddenAdditivesHref = showHiddenCountLink
-    ? buildShowClassesHref(`/origin/${originSlug}`, resolvedSearchParams)
+    ? buildShowClassesHref(`/origin/${originSlug}`, undefined)
     : null;
   const label = formatFilterLabel(originValue);
   const reportMistakeName = label ? `Origin - ${label}` : null;
@@ -211,28 +204,19 @@ export default async function OriginPage({ params, searchParams }: OriginPagePro
             functionOptions={functionOptions}
             originOptions={originOptions}
             currentFilter={{ type: 'origin', slug: originSlug }}
-            currentSortMode={sortMode}
-            currentShowClasses={showClasses}
+            currentSortMode={initialSortMode}
+            currentShowClasses={initialShowClasses}
           />
         </Suspense>
-        {useInfiniteScroll ? (
-          <AdditiveGridInfinite
-            initialItems={initialItems}
-            totalCount={totalCount}
-            sortMode={sortMode}
-            showClasses={showClasses}
-            chunkSize={chunkSize}
-            filter={{ type: 'origin', slug: originSlug }}
-            awarenessScores={awarenessResult.scores}
-          />
-        ) : (
-          <AdditiveGrid
-            items={initialItems}
-            sortMode={sortMode}
-            emptyMessage="No additives found for this origin."
-            awarenessScores={awarenessResult.scores}
-          />
-        )}
+        <AdditiveGridInfinite
+          initialItems={initialItems}
+          totalCount={totalCount}
+          initialSortMode={initialSortMode}
+          initialShowClasses={initialShowClasses}
+          chunkSize={chunkSize}
+          filter={{ type: 'origin', slug: originSlug }}
+          awarenessScores={awarenessResult.scores}
+        />
       </Box>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,7 @@ import {
   getOriginFilters,
   filterAdditivesByClassVisibility,
   getFunctionSlug,
-  parseAdditiveSortMode,
-  parseShowClassesParam,
+  DEFAULT_ADDITIVE_SORT_MODE,
   sortAdditivesByMode,
   mapAdditivesToGridItems,
   getAwarenessScores,
@@ -126,19 +125,11 @@ const functionsHref = '/function';
 
 const highlightNumberSx = { fontWeight: 600, color: '#ffffff' } as const;
 
-interface HomePageProps {
-  searchParams?: Promise<{
-    sort?: string | string[];
-    classes?: string | string[];
-  }>;
-}
-
-export default async function HomePage({ searchParams }: HomePageProps) {
-  const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const sortMode = parseAdditiveSortMode(resolvedSearchParams?.sort ?? null);
-  const showClasses = parseShowClassesParam(resolvedSearchParams?.classes ?? null);
-  const filteredAdditives = filterAdditivesByClassVisibility(additives, showClasses);
-  const sortedAdditives = sortAdditivesByMode(filteredAdditives, sortMode);
+export default async function HomePage() {
+  const initialSortMode = DEFAULT_ADDITIVE_SORT_MODE;
+  const initialShowClasses = false;
+  const filteredAdditives = filterAdditivesByClassVisibility(additives, initialShowClasses);
+  const sortedAdditives = sortAdditivesByMode(filteredAdditives, initialSortMode);
   const chunkSize = 100;
   const totalCount = sortedAdditives.length;
   const awarenessResult = getAwarenessScores();
@@ -371,15 +362,15 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         <FilterPanel
           functionOptions={functionOptions}
           originOptions={originOptions}
-          currentSortMode={sortMode}
-          currentShowClasses={showClasses}
+          currentSortMode={initialSortMode}
+          currentShowClasses={initialShowClasses}
         />
       </Suspense>
       <AdditiveGridInfinite
         initialItems={initialItems}
         totalCount={totalCount}
-        sortMode={sortMode}
-        showClasses={showClasses}
+        initialSortMode={initialSortMode}
+        initialShowClasses={initialShowClasses}
         chunkSize={chunkSize}
         awarenessScores={awarenessResult.scores}
       />

--- a/src/components/AdditiveComparison.tsx
+++ b/src/components/AdditiveComparison.tsx
@@ -559,7 +559,14 @@ export function AdditiveComparison({ initialSelection, initialAdditives, awarene
         <Typography
           variant="body1"
           color="text.secondary"
-          sx={{ display: 'flex', alignItems: 'center', gap: 1, lineHeight: 1.6 }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            lineHeight: 1.6,
+            flexWrap: 'nowrap',
+            minHeight: 32,
+          }}
         >
           <AwarenessScoreChip score={awarenessScore} />
           {awarenessLevel ? <Box component="span">{awarenessLevel}</Box> : null}

--- a/src/components/AdditiveGrid.tsx
+++ b/src/components/AdditiveGrid.tsx
@@ -15,7 +15,7 @@ import { SearchSparkline } from './SearchSparkline';
 import { theme } from '../lib/theme';
 import { FunctionChipList } from './FunctionChipList';
 import { useCompareFlap } from './CompareFlap';
-import type { AwarenessScoreResult } from '../lib/awareness';
+import type { AwarenessScoreDisplay, AwarenessScoreResult } from '../lib/awareness';
 import { AwarenessScoreChip } from './AwarenessScoreChip';
 
 const GRID_DEFAULT_SORT_MODE: AdditiveSortMode = 'product-count';
@@ -55,7 +55,7 @@ interface AdditiveGridProps {
   items: AdditiveGridItemType[];
   emptyMessage?: string;
   sortMode?: AdditiveSortMode;
-  awarenessScores?: Map<string, AwarenessScoreResult>;
+  awarenessScores?: Map<string, AwarenessScoreDisplay | AwarenessScoreResult>;
 }
 
 export function AdditiveGrid({
@@ -111,7 +111,7 @@ interface AdditiveGridCardProps {
   additive: AdditiveGridItemType;
   index: number;
   sortMode: AdditiveSortMode;
-  awarenessScore: AwarenessScoreResult | null | undefined;
+  awarenessScore: AwarenessScoreDisplay | AwarenessScoreResult | null | undefined;
   dragEnabled: boolean;
   compareDragging: boolean;
 }

--- a/src/components/AdditiveGridInfinite.tsx
+++ b/src/components/AdditiveGridInfinite.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Box, Button, CircularProgress, Typography } from '@mui/material';
 
 import type { AdditiveGridItem, AdditiveSortMode } from '../lib/additives';
 import { AdditiveGrid } from './AdditiveGrid';
-import { loadAdditivesBatch } from '../app/actions/additives';
 import type { AwarenessScoreResult } from '../lib/awareness';
 
 type AdditiveGridFilter =
@@ -21,8 +21,8 @@ type AdditiveGridFilter =
 interface AdditiveGridInfiniteProps {
   initialItems: AdditiveGridItem[];
   totalCount: number;
-  sortMode: AdditiveSortMode;
-  showClasses: boolean;
+  initialSortMode: AdditiveSortMode;
+  initialShowClasses: boolean;
   chunkSize?: number;
   filter?: AdditiveGridFilter | null;
   awarenessScores?: Map<string, AwarenessScoreResult>;
@@ -33,35 +33,158 @@ const DEFAULT_CHUNK_SIZE = 100;
 export function AdditiveGridInfinite({
   initialItems,
   totalCount,
-  sortMode,
-  showClasses,
+  initialSortMode,
+  initialShowClasses,
   chunkSize = DEFAULT_CHUNK_SIZE,
   filter = null,
   awarenessScores,
 }: AdditiveGridInfiniteProps) {
+  const searchParams = useSearchParams();
+  const sortParam = searchParams.get('sort');
+  const classesParam = searchParams.get('classes');
+  const filterKey = filter ? `${filter.type}:${filter.slug}` : 'none';
   const [items, setItems] = useState<AdditiveGridItem[]>(initialItems);
   const [count, setCount] = useState(totalCount);
   const [offset, setOffset] = useState(initialItems.length);
   const [hasMore, setHasMore] = useState(initialItems.length < totalCount);
   const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const isFetchingRef = useRef(false);
   const safeChunkSize = Number.isFinite(chunkSize) && chunkSize > 0 ? Math.floor(chunkSize) : DEFAULT_CHUNK_SIZE;
-  const filterKey = filter ? `${filter.type}:${filter.slug}` : 'none';
+  const parseSortMode = useCallback(
+    (value: string | null): AdditiveSortMode => {
+      const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+      if (normalized === 'products' || normalized === 'product-count') {
+        return 'product-count';
+      }
+
+      if (normalized === 'search-rank' || normalized === 'rank') {
+        return 'search-rank';
+      }
+
+      if (normalized === 'awareness' || normalized === 'awareness-score') {
+        return 'awareness';
+      }
+
+      if (normalized === 'e-number' || normalized === 'enumber' || normalized === 'e') {
+        return 'e-number';
+      }
+
+      return initialSortMode;
+    },
+    [initialSortMode],
+  );
+
+  const parseShowClasses = useCallback((value: string | null): boolean => {
+    const raw = typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+    if (!raw) {
+      return initialShowClasses;
+    }
+
+    return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'show';
+  }, [initialShowClasses]);
+
+  const sortMode = useMemo(() => parseSortMode(sortParam), [parseSortMode, sortParam]);
+  const showClasses = useMemo(() => parseShowClasses(classesParam), [classesParam, parseShowClasses]);
+
+  const fetchBatch = useCallback(
+    async (requestedOffset: number, signal?: AbortSignal) => {
+      const params = new URLSearchParams();
+      params.set('offset', Number.isFinite(requestedOffset) && requestedOffset > 0 ? `${requestedOffset}` : '0');
+      params.set('sort', sortMode);
+
+      if (showClasses) {
+        params.set('classes', '1');
+      }
+
+      if (filter) {
+        params.set('filterType', filter.type);
+        params.set('filterSlug', filter.slug);
+      }
+
+      const response = await fetch(`/api/additives?${params.toString()}`, {
+        headers: { Accept: 'application/json' },
+        signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      return (await response.json()) as {
+        items: AdditiveGridItem[];
+        nextOffset: number | null;
+        totalCount: number;
+      };
+    },
+    [filter, showClasses, sortMode],
+  );
 
   useEffect(() => {
-    setItems(initialItems);
-    setCount(totalCount);
-    setOffset(initialItems.length);
-    setHasMore(initialItems.length < totalCount);
-    setError(null);
+    const currentConfigKey = `${sortMode}|${showClasses}|${filterKey}`;
+    const initialConfigKey = `${initialSortMode}|${initialShowClasses}|${filterKey}`;
+
     isFetchingRef.current = false;
-  }, [initialItems, totalCount, sortMode, showClasses, filterKey]);
+
+    if (currentConfigKey === initialConfigKey) {
+      setItems(initialItems);
+      setCount(totalCount);
+      setOffset(initialItems.length);
+      setHasMore(initialItems.length < totalCount);
+      setError(null);
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    const loadInitial = async () => {
+      setIsRefreshing(true);
+      try {
+        const result = await fetchBatch(0, abortController.signal);
+        const nextCount = typeof result.totalCount === 'number' ? result.totalCount : 0;
+        const nextOffset =
+          typeof result.nextOffset === 'number'
+            ? result.nextOffset
+            : Math.min(nextCount, result.items.length);
+
+        setItems(Array.isArray(result.items) ? result.items : []);
+        setCount(nextCount);
+        setOffset(nextOffset);
+        setHasMore(nextOffset < nextCount);
+        setError(null);
+      } catch (loadError) {
+        if ((loadError as Error).name !== 'AbortError') {
+          console.error('Failed to load additives chunk', loadError);
+          setError('Unable to load additives. Try again?');
+        }
+      } finally {
+        isFetchingRef.current = false;
+        setIsRefreshing(false);
+      }
+    };
+
+    loadInitial();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [
+    fetchBatch,
+    filterKey,
+    initialItems,
+    initialShowClasses,
+    initialSortMode,
+    showClasses,
+    sortMode,
+    totalCount,
+  ]);
 
   const fetchNext = useCallback(
     (force = false) => {
-      if ((!force && error) || !hasMore || isFetchingRef.current) {
+      if ((!force && error) || !hasMore || isFetchingRef.current || isRefreshing) {
         return;
       }
 
@@ -71,16 +194,8 @@ export function AdditiveGridInfinite({
 
       isFetchingRef.current = true;
 
-      startTransition(async () => {
-        try {
-          const result = await loadAdditivesBatch({
-            offset,
-            limit: safeChunkSize,
-            sortMode,
-            showClasses,
-            filter,
-          });
-
+      fetchBatch(offset)
+        .then((result) => {
           if (Array.isArray(result.items) && result.items.length > 0) {
             setItems((current) => [...current, ...result.items]);
           }
@@ -95,17 +210,16 @@ export function AdditiveGridInfinite({
           setOffset(nextOffset);
           setHasMore(nextOffset < nextCount);
           setError(null);
-        } catch (loadError) {
+        })
+        .catch((loadError) => {
           console.error('Failed to load additives chunk', loadError);
           setError('Unable to load more additives. Try again?');
+        })
+        .finally(() => {
           isFetchingRef.current = false;
-          return;
-        }
-
-        isFetchingRef.current = false;
-      });
+        });
     },
-    [count, error, filter, hasMore, offset, safeChunkSize, showClasses, sortMode],
+    [error, hasMore, isRefreshing, fetchBatch, offset, safeChunkSize, count],
   );
 
   useEffect(() => {
@@ -138,7 +252,7 @@ export function AdditiveGridInfinite({
     fetchNext(true);
   }, [fetchNext]);
 
-  const showLoader = (hasMore && !error) || isPending || isFetchingRef.current;
+  const showLoader = (hasMore && !error) || isRefreshing || isFetchingRef.current;
   const showEndLabel = !hasMore && items.length > 0;
 
   return (

--- a/src/components/AdditiveGridInfinite.tsx
+++ b/src/components/AdditiveGridInfinite.tsx
@@ -6,7 +6,7 @@ import { Box, Button, CircularProgress, Typography } from '@mui/material';
 
 import type { AdditiveGridItem, AdditiveSortMode } from '../lib/additives';
 import { AdditiveGrid } from './AdditiveGrid';
-import type { AwarenessScoreResult } from '../lib/awareness';
+import type { AwarenessScoreDisplay, AwarenessScoreResult } from '../lib/awareness';
 
 type AdditiveGridFilter =
   | {
@@ -25,7 +25,7 @@ interface AdditiveGridInfiniteProps {
   initialShowClasses: boolean;
   chunkSize?: number;
   filter?: AdditiveGridFilter | null;
-  awarenessScores?: Map<string, AwarenessScoreResult>;
+  awarenessScores?: Map<string, AwarenessScoreDisplay | AwarenessScoreResult>;
 }
 
 const DEFAULT_CHUNK_SIZE = 100;

--- a/src/components/AwarenessScoreChip.tsx
+++ b/src/components/AwarenessScoreChip.tsx
@@ -137,25 +137,11 @@ export function AwarenessScoreChip({
         slotProps={{ tooltip: { sx: { pointerEvents: 'auto' } } }}
       >
         <Chip
+          component="span"
+          clickable={false}
+          tabIndex={-1}
           size={size}
           label={label}
-          onClick={(event: SyntheticEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
-          onPointerDown={(event: SyntheticEvent) => {
-            event.stopPropagation();
-          }}
-          onPointerUp={(event: SyntheticEvent) => {
-            event.stopPropagation();
-          }}
-          onTouchStart={(event: SyntheticEvent) => {
-            event.stopPropagation();
-          }}
-          onTouchEnd={(event: SyntheticEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
           sx={{
             bgcolor: backgroundColor,
             color: '#ffffff',
@@ -163,6 +149,9 @@ export function AwarenessScoreChip({
             borderRadius: '999px',
             fontVariantNumeric: 'tabular-nums',
             cursor: 'default',
+            display: 'inline-flex',
+            alignItems: 'center',
+            minHeight: 24,
             '& .MuiChip-label': {
               px: 1.25,
               py: 0.5,

--- a/src/components/AwarenessScoreChip.tsx
+++ b/src/components/AwarenessScoreChip.tsx
@@ -4,7 +4,7 @@ import type { SyntheticEvent } from 'react';
 import { Box, Chip, Link as MuiLink, Stack, Tooltip, Typography } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
 
-import type { AwarenessScoreResult } from '../lib/awareness';
+import type { AwarenessScoreDisplay } from '../lib/awareness';
 import { getAwarenessLevel } from '../lib/awareness';
 
 const START_COLOR = { r: 194, g: 159, b: 251 } as const;
@@ -93,7 +93,7 @@ const buildTooltipContent = (index: number, formattedIndex: string) => {
 };
 
 interface AwarenessScoreChipProps {
-  score: AwarenessScoreResult | null | undefined;
+  score: AwarenessScoreDisplay | null | undefined;
   size?: 'small' | 'medium';
   sx?: SxProps<Theme>;
   /**

--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -9,11 +9,11 @@ import { formatOriginLabel } from '../lib/additive-format';
 import { getOriginAbbreviation, getOriginIcon } from '../lib/origin-icons';
 import { FunctionChipList } from './FunctionChipList';
 import { AwarenessScoreChip } from './AwarenessScoreChip';
-import type { AwarenessScoreResult } from '../lib/awareness';
+import type { AwarenessScoreDisplay, AwarenessScoreResult } from '../lib/awareness';
 
 interface FeaturedCardProps {
   additive: AdditiveGridItem;
-  awarenessScore: AwarenessScoreResult | null | undefined;
+  awarenessScore: AwarenessScoreDisplay | AwarenessScoreResult | null | undefined;
 }
 
 export function FeaturedCard({ additive, awarenessScore }: FeaturedCardProps) {

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -69,11 +69,6 @@ export function FilterPanel({
   >(null);
   const [showClassesControlVisible, setShowClassesControlVisible] = useState(currentShowClasses);
 
-  useEffect(() => {
-    if (currentShowClasses) {
-      setShowClassesControlVisible(true);
-    }
-  }, [currentShowClasses]);
   type SortSelectValue = 'search-rank' | 'products' | 'awareness' | 'e-number';
   const mapSortModeToSelectValue = (mode: AdditiveSortMode): SortSelectValue => {
     switch (mode) {
@@ -88,7 +83,60 @@ export function FilterPanel({
     }
   };
 
-  const currentSortValue = mapSortModeToSelectValue(currentSortMode);
+  const parseSortFromParam = (value: string | null): AdditiveSortMode | null => {
+    const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+    if (normalized === 'products' || normalized === 'product-count') {
+      return 'product-count';
+    }
+
+    if (normalized === 'search-rank' || normalized === 'rank') {
+      return 'search-rank';
+    }
+
+    if (normalized === 'awareness' || normalized === 'awareness-score') {
+      return 'awareness';
+    }
+
+    if (normalized === 'e-number' || normalized === 'enumber' || normalized === 'e') {
+      return 'e-number';
+    }
+
+    return null;
+  };
+
+  const parseShowClassesFromParam = (value: string | null): boolean | null => {
+    const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+    if (!normalized) {
+      return null;
+    }
+
+    return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'show';
+  };
+
+  const derivedSortMode = (() => {
+    const paramValue = searchParams?.get('sort') ?? null;
+    const parsed = parseSortFromParam(paramValue);
+    return parsed ?? currentSortMode ?? DEFAULT_SORT_MODE;
+  })();
+
+  const derivedShowClasses = (() => {
+    const paramValue = searchParams?.get('classes') ?? null;
+    const parsed = parseShowClassesFromParam(paramValue);
+    if (parsed === null) {
+      return currentShowClasses ?? false;
+    }
+    return parsed;
+  })();
+
+  useEffect(() => {
+    if (derivedShowClasses) {
+      setShowClassesControlVisible(true);
+    }
+  }, [derivedShowClasses]);
+
+  const currentSortValue = mapSortModeToSelectValue(derivedSortMode);
 
   const closeLegend = useCallback(() => {
     setLegendOpen(false);
@@ -143,7 +191,7 @@ export function FilterPanel({
   const buildUrlWithState = (
     path: string,
     sort: SortSelectValue = currentSortValue,
-    showClasses: boolean = currentShowClasses,
+    showClasses: boolean = derivedShowClasses,
   ) => {
     const params = new URLSearchParams(searchParams?.toString() ?? '');
 
@@ -320,7 +368,7 @@ export function FilterPanel({
                 control={
                   <Checkbox
                     size="small"
-                    checked={currentShowClasses}
+                    checked={derivedShowClasses}
                     onChange={handleShowClassesChange}
                     disabled={isPending}
                   />

--- a/src/lib/additives.ts
+++ b/src/lib/additives.ts
@@ -725,20 +725,24 @@ export const getAdditivesByOriginSlug = (slug: string): Additive[] => {
   );
 };
 
-export type AdditiveGridItem = Pick<
-  Additive,
-  | 'slug'
-  | 'title'
-  | 'eNumber'
-  | 'functions'
-  | 'origin'
-  | 'searchSparkline'
-  | 'searchVolume'
-  | 'searchRank'
-  | 'productCount'
-  | 'childSlugs'
-  | 'awarenessScore'
->;
+export type AwarenessScoreSummary = {
+  index: number;
+  colorScore: number | null;
+};
+
+export type AdditiveGridItem = {
+  slug: string;
+  title: string;
+  eNumber: string;
+  functions: string[];
+  origin: string[];
+  searchSparkline: Array<number | null>;
+  searchVolume: number | null;
+  searchRank: number | null;
+  productCount: number | null;
+  childSlugs: string[];
+  awarenessScore: AwarenessScoreSummary | null;
+};
 
 export const toAdditiveGridItem = (additive: Additive): AdditiveGridItem => ({
   slug: additive.slug,
@@ -751,7 +755,12 @@ export const toAdditiveGridItem = (additive: Additive): AdditiveGridItem => ({
   searchRank: additive.searchRank,
   productCount: additive.productCount,
   childSlugs: [...additive.childSlugs],
-  awarenessScore: additive.awarenessScore,
+  awarenessScore: additive.awarenessScore
+    ? {
+        index: additive.awarenessScore.index,
+        colorScore: additive.awarenessScore.colorScore ?? null,
+      }
+    : null,
 });
 
 export const mapAdditivesToGridItems = (items: Additive[]): AdditiveGridItem[] =>

--- a/src/lib/awareness.ts
+++ b/src/lib/awareness.ts
@@ -16,6 +16,11 @@ export interface AwarenessScoreResult {
   colorScore: number;
 }
 
+export type AwarenessScoreDisplay = {
+  index: number;
+  colorScore?: number | null;
+};
+
 export interface AwarenessComputationResult {
   /** Laplace smoothing weight applied to both search volume and product count. */
   alpha: number;
@@ -183,4 +188,3 @@ export const getAwarenessLevel = (index: number | null | undefined): AwarenessLe
 
   return 'normal';
 };
-


### PR DESCRIPTION
Right now sorting is broken on production. If we choose any option in "Sort by" grid controll - nothing happends (no output in console either).

> Found the root cause: the home/function/origin pages were forced static (dynamic = 'force-static'), so search-param sort changes kept returning the cached product-count ordering

Via Codex / local